### PR TITLE
Rename Modules.loop() to Modules.start()

### DIFF
--- a/i3pyblocks/core.py
+++ b/i3pyblocks/core.py
@@ -44,7 +44,7 @@ class Runner:
         self, module: modules.Module, signals: Iterable[int] = ()
     ) -> None:
         self._modules[module.instance] = module
-        self.register_task(module.loop())
+        self.register_task(module.start())
 
         if signals:
             self.register_signal(module, signals)

--- a/i3pyblocks/modules/__init__.py
+++ b/i3pyblocks/modules/__init__.py
@@ -119,7 +119,7 @@ class Module(metaclass=abc.ABCMeta):
         raise NotImplementedError("Should implement signal_handler method")
 
     @abc.abstractmethod
-    async def loop(self) -> None:
+    async def start(self) -> None:
         pass
 
 
@@ -138,7 +138,7 @@ class PollingModule(Module):
     def signal_handler(self, *_, **__) -> None:
         self.run()
 
-    async def loop(self) -> None:
+    async def start(self) -> None:
         try:
             while True:
                 self.run()
@@ -157,7 +157,7 @@ class ThreadingModule(Module):
     def run(self) -> None:
         pass
 
-    async def loop(self) -> None:
+    async def start(self) -> None:
         try:
             loop = asyncio.get_running_loop()
             await loop.run_in_executor(self._executor, self.run)

--- a/i3pyblocks/modules/pulsectl.py
+++ b/i3pyblocks/modules/pulsectl.py
@@ -70,15 +70,14 @@ class PulseAudioModule(modules.ThreadingModule):
         default_sink_name = server_info.default_sink_name
         sink_list = self.pulse.sink_list()
 
-        if len(sink_list) == 0:
-            raise ValueError("No sinks found")
-        else:
-            self.sink_index = next(
-                # Find the sink with default_sink_name
-                (sink.index for sink in sink_list if sink.name == default_sink_name),
-                # Returns the first from the list as fallback
-                0,
-            )
+        assert len(sink_list) > 0, "No sinks found"
+
+        self.sink_index = next(
+            # Find the sink with default_sink_name
+            (sink.index for sink in sink_list if sink.name == default_sink_name),
+            # Returns the first from the list as fallback
+            0,
+        )
 
     def _update_sink_info(self) -> None:
         self.sink = self.pulse.sink_info(self.sink_index)

--- a/tests/modules/test_modules.py
+++ b/tests/modules/test_modules.py
@@ -16,7 +16,7 @@ def test_invalid_module():
 @pytest.mark.asyncio
 async def test_valid_module(mock_uuid4):
     class ValidModule(Module):
-        async def loop(self):
+        async def start(self):
             self.update("Done!", color=None, urgent=False, markup=Markup.NONE)
 
         def click_handler(self, *_, **__):
@@ -61,7 +61,7 @@ async def test_valid_module(mock_uuid4):
         "markup": "pango",
     }
 
-    await module.loop()
+    await module.start()
 
     assert module.result() == {
         "align": "center",
@@ -106,7 +106,7 @@ async def test_valid_polling_module(mock_uuid4):
 
     module = ValidPollingModule()
 
-    task = asyncio.ensure_future(module.loop())
+    task = asyncio.create_task(module.start())
 
     await asyncio.wait([task], timeout=0.5)
 
@@ -133,7 +133,7 @@ async def test_polling_module_with_error(mock_uuid4):
 
     module = PollingModuleWithError()
 
-    await module.loop()
+    await module.start()
 
     assert module.result() == {
         "full_text": "Exception in PollingModuleWithError: Boom!",
@@ -156,7 +156,7 @@ async def test_valid_thread_pool_module(mock_uuid4):
 
     module = ValidThreadingModule()
 
-    task = asyncio.ensure_future(module.loop())
+    task = asyncio.create_task(module.start())
 
     await asyncio.wait([task])
 
@@ -179,7 +179,7 @@ async def test_thread_pool_module_with_error(mock_uuid4):
 
     module = ThreadingModuleWithError()
 
-    task = asyncio.ensure_future(module.loop())
+    task = asyncio.create_task(module.start())
 
     await asyncio.wait([task])
 

--- a/tests/modules/test_pulsectl.py
+++ b/tests/modules/test_pulsectl.py
@@ -9,5 +9,5 @@ from i3pyblocks.modules import pulsectl as m_pulsectl
 def test_pulse_audio_module(mocker):
     mocker.patch.object(pulsectl, "Pulse")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(AssertionError):
         m_pulsectl.PulseAudioModule()


### PR DESCRIPTION
This reflects better what the function does, since a module does not necessary runs on a loop (but most of them does).