### PR TITLE
Use json.dumps directly instead of concating strings

### DIFF
--- a/i3pyblocks/core.py
+++ b/i3pyblocks/core.py
@@ -69,8 +69,8 @@ class Runner:
     async def write_results(self) -> None:
         while True:
             await self.update_results()
-            output = [json.dumps(r) for r in self.results.values() if r]
-            print("[" + ",".join(output) + "],", flush=True)
+            output = list(self.results.values())
+            print(json.dumps(output), end=",\n", flush=True)
 
     async def click_event(self, raw: AnyStr) -> None:
         try:
@@ -119,7 +119,7 @@ class Runner:
         self.register_task(self.click_events())
         self.register_task(self.write_results())
 
-        print('{"version": 1, "click_events": true}\n[', flush=True)
+        print(json.dumps({"version": 1, "click_events": True}), end="\n[\n", flush=True)
 
         await asyncio.wait(self.tasks, timeout=timeout)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -46,20 +46,20 @@ async def test_runner(capsys, mock_stdin):
         == f"""\
 {{"version": 1, "click_events": true}}
 [
-[{{"name": "instance_1", "instance": "{instance_1.id}", "full_text": "1"}},\
-{{"name": "instance_2", "instance": "{instance_2.id}", "full_text": "1"}},\
+[{{"name": "instance_1", "instance": "{instance_1.id}", "full_text": "1"}}, \
+{{"name": "instance_2", "instance": "{instance_2.id}", "full_text": "1"}}, \
 {{"name": "instance_3", "instance": "{instance_3.id}", "full_text": "1"}}],
-[{{"name": "instance_1", "instance": "{instance_1.id}", "full_text": "2"}},\
-{{"name": "instance_2", "instance": "{instance_2.id}", "full_text": "2"}},\
+[{{"name": "instance_1", "instance": "{instance_1.id}", "full_text": "2"}}, \
+{{"name": "instance_2", "instance": "{instance_2.id}", "full_text": "2"}}, \
 {{"name": "instance_3", "instance": "{instance_3.id}", "full_text": "2"}}],
-[{{"name": "instance_1", "instance": "{instance_1.id}", "full_text": "3"}},\
-{{"name": "instance_2", "instance": "{instance_2.id}", "full_text": "3"}},\
+[{{"name": "instance_1", "instance": "{instance_1.id}", "full_text": "3"}}, \
+{{"name": "instance_2", "instance": "{instance_2.id}", "full_text": "3"}}, \
 {{"name": "instance_3", "instance": "{instance_3.id}", "full_text": "3"}}],
-[{{"name": "instance_1", "instance": "{instance_1.id}", "full_text": "4"}},\
-{{"name": "instance_2", "instance": "{instance_2.id}", "full_text": "4"}},\
+[{{"name": "instance_1", "instance": "{instance_1.id}", "full_text": "4"}}, \
+{{"name": "instance_2", "instance": "{instance_2.id}", "full_text": "4"}}, \
 {{"name": "instance_3", "instance": "{instance_3.id}", "full_text": "4"}}],
-[{{"name": "instance_1", "instance": "{instance_1.id}", "full_text": "5"}},\
-{{"name": "instance_2", "instance": "{instance_2.id}", "full_text": "5"}},\
+[{{"name": "instance_1", "instance": "{instance_1.id}", "full_text": "5"}}, \
+{{"name": "instance_2", "instance": "{instance_2.id}", "full_text": "5"}}, \
 {{"name": "instance_3", "instance": "{instance_3.id}", "full_text": "5"}}],
 """
     )


### PR DESCRIPTION
Easier to read, and maybe it performs better too since it avoid a loop and reduce N `json.dumps` calls to 1 (but I didn't measure it).

BTW, I sometimes forgot how Python's `print` is clever (specially for those `end` hacks).