### PR TITLE
Implement Module.abort()

### DIFF
--- a/i3pyblocks/core.py
+++ b/i3pyblocks/core.py
@@ -38,8 +38,11 @@ class Runner:
                     f"Module {module.name} with id {module.id} received a signal {sig.name}"
                 )
                 await module.signal_handler(sig=sig)
-            except Exception:
+            except Exception as e:
                 logger.exception(f"Exception in {module.name} signal handler")
+                module.abort(
+                    f"Exception in {module.name} signal handler: {e}", urgent=True
+                )
 
         def callback_fn(sig: signal.Signals):
             return asyncio.create_task(signal_handler(sig))
@@ -106,8 +109,9 @@ class Runner:
                 height=click_event.get("height"),
                 modifiers=click_event.get("modifiers"),
             )
-        except Exception:
+        except Exception as e:
             logger.exception(f"Error in {module.name} click handler")
+            module.abort(f"Exception in {module.name} click handler: {e}", urgent=True)
 
     # Based on: https://git.io/fjbHx
     async def click_events(self) -> None:

--- a/tests/modules/test_modules.py
+++ b/tests/modules/test_modules.py
@@ -100,6 +100,35 @@ async def test_valid_module():
         "markup": "none",
     }
 
+    module.abort("Aborted!")
+
+    _, result = await module.update_queue.get()
+
+    assert result == {
+        "align": "center",
+        "background": "#FFFFFF",
+        "border": "#FF0000",
+        "border_bottom": 1,
+        "border_left": 1,
+        "border_right": 1,
+        "border_top": 1,
+        "color": "#000000",
+        "full_text": "Aborted!",
+        "instance": str(module.id),
+        "min_width": 10,
+        "name": "Name",
+        "separator": False,
+        "separator_block_width": 9,
+        "urgent": True,
+        "markup": "pango",
+    }
+
+    module.update("Shouldn't update since aborted")
+
+    with pytest.raises(asyncio.QueueEmpty):
+        await module.update_queue.get_nowait()
+
+    # click_handler() by default should raise NotImplementedError
     with pytest.raises(NotImplementedError):
         await module.click_handler(
             x=1,
@@ -112,6 +141,7 @@ async def test_valid_module():
             modifiers=[],
         )
 
+    # signal_handler() by default should raise NotImplementedError
     with pytest.raises(NotImplementedError):
         await module.signal_handler(sig=signal.SIGHUP)
 


### PR DESCRIPTION
This method allows us to make a last update in the module and stops it from updating. Useful for reporting exception (since we want exceptions to be seem).

Fix issue #90.