### PR TITLE
Remove {click,signal}_handler exception

### DIFF
--- a/i3pyblocks/modules/__init__.py
+++ b/i3pyblocks/modules/__init__.py
@@ -132,10 +132,10 @@ class Module(metaclass=abc.ABCMeta):
         height: int,
         modifiers: List[Optional[str]],
     ) -> None:
-        raise NotImplementedError("Should implement click_handler method")
+        pass
 
     async def signal_handler(self, *, sig: signal.Signals) -> None:
-        raise NotImplementedError("Should implement signal_handler method")
+        pass
 
     @abc.abstractmethod
     async def start(self, queue: asyncio.Queue = None) -> None:

--- a/tests/modules/test_modules.py
+++ b/tests/modules/test_modules.py
@@ -128,23 +128,6 @@ async def test_valid_module():
     with pytest.raises(asyncio.QueueEmpty):
         await module.update_queue.get_nowait()
 
-    # click_handler() by default should raise NotImplementedError
-    with pytest.raises(NotImplementedError):
-        await module.click_handler(
-            x=1,
-            y=1,
-            button=1,
-            relative_x=1,
-            relative_y=1,
-            width=1,
-            height=1,
-            modifiers=[],
-        )
-
-    # signal_handler() by default should raise NotImplementedError
-    with pytest.raises(NotImplementedError):
-        await module.signal_handler(sig=signal.SIGHUP)
-
 
 def test_invalid_polling_module():
     class InvalidPollingModule(modules.PollingModule):


### PR DESCRIPTION
This would make them sometimes necessary to override for non good reason.