### PR TITLE
Reconnect to Pulse in case of error

### DIFF
--- a/i3pyblocks/modules/pulsectl.py
+++ b/i3pyblocks/modules/pulsectl.py
@@ -1,4 +1,5 @@
 import subprocess
+import time
 from typing import Sequence
 
 import pulsectl
@@ -46,33 +47,12 @@ class PulseAudioModule(modules.ExecutorModule):
         self.pulse = self.pulsectl.Pulse(__name__, connect=False, threading_lock=True)
         self._initialize_pulse()
 
-    def __exit__(self, *_) -> None:
-        super().__exit__()
-        self.pulse.close()
-
     def _initialize_pulse(self):
         self.pulse.connect(autospawn=True)
 
         self._find_sink_index()
         self._update_sink_info()
         self._setup_event_callback()
-
-    def _setup_event_callback(self) -> None:
-        def event_callback(event):
-            self.event = event
-            raise self.pulsectl.PulseLoopStop()
-
-        self.pulse.event_mask_set("sink", "server")
-        self.pulse.event_callback_set(event_callback)
-
-    def _handle_event(self) -> None:
-        self.pulse.event_listen()
-
-        if self.event.facility == "server":
-            self._find_sink_index()
-            self._update_sink_info()
-        elif self.event.facility == "sink":
-            self._update_sink_info()
 
     def _find_sink_index(self) -> None:
         server_info = self.pulse.server_info()
@@ -92,15 +72,29 @@ class PulseAudioModule(modules.ExecutorModule):
         try:
             self.sink = self.pulse.sink_info(self.sink_index)
         except pulsectl.PulseError:
+            # Waiting a little before trying to connect again so we don't
+            # burn CPU in a infinity loop
+            time.sleep(0.5)
             self._initialize_pulse()
 
-    def _toggle_mute(self):
-        if self.sink.mute:
-            self.pulse.mute(self.sink, mute=False)
-        else:
-            self.pulse.mute(self.sink, mute=True)
+    def _setup_event_callback(self) -> None:
+        def _event_callback(event):
+            self.event = event
+            raise self.pulsectl.PulseLoopStop()
 
-    def _update_status(self):
+        self.pulse.event_mask_set("sink", "server")
+        self.pulse.event_callback_set(_event_callback)
+
+    def handle_event(self) -> None:
+        self.pulse.event_listen()
+
+        if self.event.facility == "server":
+            self._find_sink_index()
+            self._update_sink_info()
+        elif self.event.facility == "sink":
+            self._update_sink_info()
+
+    def update_status(self):
         if self.sink.mute:
             self.update(self.format_mute.format(), color=types.Color.URGENT)
         else:
@@ -109,19 +103,25 @@ class PulseAudioModule(modules.ExecutorModule):
             icon = utils.calculate_threshold(self.icons, volume)
             self.update(self.format.format(volume=volume, icon=icon), color=color)
 
+    def toggle_mute(self):
+        if self.sink.mute:
+            self.pulse.mute(self.sink, mute=False)
+        else:
+            self.pulse.mute(self.sink, mute=True)
+
     async def click_handler(self, button: int, *_, **__) -> None:
         if button == types.Mouse.LEFT_BUTTON:
             self.subprocess.Popen(self.command)
         elif button == types.Mouse.RIGHT_BUTTON:
-            self._toggle_mute()
+            self.toggle_mute()
         elif button == types.Mouse.SCROLL_UP:
             self.pulse.volume_change_all_chans(self.sink, 0.05)
         elif button == types.Mouse.SCROLL_DOWN:
             self.pulse.volume_change_all_chans(self.sink, -0.05)
 
-        self._update_status()
+        self.update_status()
 
     def run(self) -> None:
         while True:
-            self._update_status()
-            self._handle_event()
+            self.update_status()
+            self.handle_event()


### PR DESCRIPTION
After suspending `Pulse` may return an error while trying to update. Probably the reason is because the sound card may not be ready yet.

So, in case of error, reconnect to `Pulse` instance.

~~Sadly, didn't find a way to write a test for this case. This module probably needs a rewrite since it is very complex.~~