### PR TITLE
Add core.Modules.setup()

### DIFF
--- a/i3pyblocks/core.py
+++ b/i3pyblocks/core.py
@@ -96,10 +96,13 @@ class Runner:
           - *signums*: any iterable containing signal numbers, can be either
         an int or a signal.Signals' enum
         """
+        # Setup the module before starting it
+        module.setup(self.queue)
+
         self.modules[module.id] = module
         # This only works correctly because from Python 3.7+ dict is ordered
         self.results[module.id] = None
-        self.register_task(module.start(self.queue))
+        self.register_task(module.start())
 
         if signals:
             self.register_signal(module, signals)

--- a/i3pyblocks/modules/aionotify.py
+++ b/i3pyblocks/modules/aionotify.py
@@ -29,9 +29,7 @@ class FileWatcherModule(modules.Module):
     async def run(self) -> None:
         pass
 
-    async def start(self, queue: asyncio.Queue = None) -> None:
-        await super().start(queue)
-
+    async def start(self) -> None:
         if not os.path.exists(self.path):
             self.abort(full_text=self.format_file_not_found.format(path=self.path))
             return

--- a/i3pyblocks/modules/i3ipc.py
+++ b/i3pyblocks/modules/i3ipc.py
@@ -1,5 +1,3 @@
-import asyncio
-
 import i3ipc
 from i3ipc.aio import Connection
 
@@ -29,9 +27,7 @@ class WindowTitleModule(modules.Module):
 
         self.update(self.format.format(window_title=window.name))
 
-    async def start(self, queue: asyncio.Queue = None) -> None:
-        await super().start(queue)
-
+    async def start(self) -> None:
         # https://git.io/Jft7j
         connection = self.i3ipc_connection(auto_reconnect=True)
         await connection.connect()

--- a/tests/modules/test_base.py
+++ b/tests/modules/test_base.py
@@ -40,6 +40,8 @@ async def test_valid_module():
         markup=types.Markup.PANGO,
     )
 
+    module.setup(asyncio.Queue())
+
     assert module.result() == {
         "align": "center",
         "background": "#FFFFFF",


### PR DESCRIPTION
This method does the setup that before was done in `core.Modules.start()`. The advantage of using a separate method for this is that the children classes don't need to explicitly call `super().start(queue)`, so there is less changes for things to go wrong. Also this hides an implementation detail.