### PR TITLE
Fix deadlock in i3pyblocks.blocks.pulsectl

### DIFF
--- a/i3pyblocks/blocks/aionotify.py
+++ b/i3pyblocks/blocks/aionotify.py
@@ -90,7 +90,7 @@ class BacklightBlock(FileWatcherBlock):
 
         self.utils = _utils
 
-    async def click_handler(self, button: int, *_, **__) -> None:
+    async def click_handler(self, button: int, **_kwargs) -> None:
         command = self.command_on_click.get(button)
 
         if not command:

--- a/i3pyblocks/blocks/datetime.py
+++ b/i3pyblocks/blocks/datetime.py
@@ -18,7 +18,7 @@ class DateTimeBlock(blocks.PollingBlock):
         self.format = self.format_time
         self.datetime = _datetime
 
-    async def click_handler(self, *_, **__) -> None:
+    async def click_handler(self, **_kwargs) -> None:
         if self.format == self.format_date:
             self.format = self.format_time
         else:

--- a/i3pyblocks/blocks/subprocess.py
+++ b/i3pyblocks/blocks/subprocess.py
@@ -26,7 +26,7 @@ class ShellBlock(blocks.PollingBlock):
         self.color_by_returncode = dict(color_by_returncode)
         self.utils = _utils
 
-    async def click_handler(self, button: int, *_, **__) -> None:
+    async def click_handler(self, button: int, **_kwargs) -> None:
         command = self.command_on_click.get(button)
 
         if not command:
@@ -77,7 +77,7 @@ class ToggleBlock(blocks.PollingBlock):
 
         return bool(output)
 
-    async def click_handler(self, *_, **__) -> None:
+    async def click_handler(self, **_kwargs) -> None:
         state = await self.get_state()
 
         if not state:


### PR DESCRIPTION
Instead of using the same instance of `Pulse()` to control get the updates and control the volume, use separate ones. This is a workaround, but until we either rework this module in a proper async or we control the internal `pulsectl` event loop correctly, this is as far as we can go.