### PR TITLE
Remove {text} from i3pyblocks.blocks.aiohttp.RequestBlock

### DIFF
--- a/example.py
+++ b/example.py
@@ -152,7 +152,7 @@ async def main():
     # RequestsBlock do a HTTP request to an url. We are using it here to show
     # the current weather for location, using
     # https://github.com/chubin/wttr.in#one-line-output
-    # For more complex requests, we can also pass a async function
+    # For more complex requests, we can also pass a custom async function
     # `response_callback`, that receives the response of the HTTP request and
     # you can manipulate it the way you want
     runner.register_block(

--- a/tests/blocks/test_aiohttp.py
+++ b/tests/blocks/test_aiohttp.py
@@ -15,7 +15,7 @@ async def test_request_block(aiohttp_server):
     instance = m_aiohttp.RequestBlock(
         url=f"http://127.0.0.1:{server.port}",
         method="post",
-        format="{status} {text}",
+        format="{status} {response}",
     )
 
     await instance.run()
@@ -61,7 +61,6 @@ async def test_request_block_with_callback(aiohttp_server):
 
     instance = m_aiohttp.RequestBlock(
         url=f"http://127.0.0.1:{server.port}",
-        format="{response_callback}",
         response_callback=json_callback,
     )
 


### PR DESCRIPTION
There isn't any reason why text should be a special case. Instead let's change the default `response_callback` function to be a function that returns the text.

This should avoid an issue of parsing the response twice if the `response_callback` also parses the response.