### PR TITLE
Only run tests for module if optional dependency is installed

### DIFF
--- a/i3pyblocks/cli.py
+++ b/i3pyblocks/cli.py
@@ -30,7 +30,9 @@ def main(args: Optional[List[str]] = None) -> None:
         required=False,
     )
     parser.add_argument(
-        "--version", action="version", version=f"%(prog)s {__version__}",
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
     )
     parsed_args = parser.parse_args(args=args)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,4 +19,4 @@ line_length=88
 src_paths=i3pyblocks,test
 
 [tool:pytest]
-addopts=-vvv --mypy-ignore-missing-imports --isort --black --flake8 --disable-warnings
+addopts=-vvv -rxs --mypy-ignore-missing-imports --isort --black --flake8 --disable-warnings

--- a/tests/blocks/test_aiohttp.py
+++ b/tests/blocks/test_aiohttp.py
@@ -1,7 +1,8 @@
-import aiohttp
-from aiohttp import web
+import pytest
 
-from i3pyblocks.blocks import aiohttp as m_aiohttp
+aiohttp = pytest.importorskip("aiohttp")
+web = pytest.importorskip("aiohttp.web")
+m_aiohttp = pytest.importorskip("i3pyblocks.blocks.aiohttp")
 
 
 async def test_polling_request_block(aiohttp_server):

--- a/tests/blocks/test_aionotify.py
+++ b/tests/blocks/test_aionotify.py
@@ -1,13 +1,14 @@
 import asyncio
 
-import aionotify
 import pytest
 from asynctest import Mock
 from helpers import misc, task
 
 from i3pyblocks import types
 from i3pyblocks._internal import utils
-from i3pyblocks.blocks import aionotify as m_aionotify
+
+aionotify = pytest.importorskip("aionotify")
+m_aionotify = pytest.importorskip("i3pyblocks.blocks.aionotify")
 
 
 @pytest.mark.asyncio

--- a/tests/blocks/test_i3ipc.py
+++ b/tests/blocks/test_i3ipc.py
@@ -1,16 +1,16 @@
-import i3ipc
-import i3ipc.aio
 import pytest
 from asynctest import CoroutineMock, Mock
 from helpers import misc, task
 
-from i3pyblocks.blocks import i3ipc as m_i3ipc
+i3ipc = pytest.importorskip("i3ipc")
+i3ipc_aio = pytest.importorskip("i3ipc.aio")
+m_i3ipc = pytest.importorskip("i3pyblocks.blocks.i3ipc")
 
 
 @pytest.mark.asyncio
 async def test_window_title_block():
     mock_i3ipc = Mock(i3ipc)
-    mock_i3ipc_aio = Mock(i3ipc.aio)
+    mock_i3ipc_aio = Mock(i3ipc_aio)
 
     mock_connection = mock_i3ipc_aio.Connection.return_value
     # For some reason asynctest.Mock didn't work here

--- a/tests/blocks/test_psutil.py
+++ b/tests/blocks/test_psutil.py
@@ -1,12 +1,13 @@
 from pathlib import Path
 from unittest.mock import Mock
 
-import psutil
 import pytest
 from helpers import misc
 
 from i3pyblocks import types
-from i3pyblocks.blocks import psutil as m_psutil
+
+psutil = pytest.importorskip("psutil")
+m_psutil = pytest.importorskip("i3pyblocks.blocks.psutil")
 
 
 @pytest.mark.asyncio

--- a/tests/blocks/test_pulsectl.py
+++ b/tests/blocks/test_pulsectl.py
@@ -1,12 +1,13 @@
 import subprocess
 from unittest.mock import Mock, call
 
-import pulsectl
 import pytest
 from helpers import misc
 
 from i3pyblocks import types
-from i3pyblocks.blocks import pulsectl as m_pulsectl
+
+pulsectl = pytest.importorskip("pulsectl")
+m_pulsectl = pytest.importorskip("i3pyblocks.blocks.pulsectl")
 
 # Stub some PulseAudio sinks
 SINK = misc.AttributeDict(description="description", index=1, name="sink", mute=0)


### PR DESCRIPTION
This would allow to the tests to run even in the case the user is missing some dependencies.