### PR TITLE
Remove mach-nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,6 +3,19 @@ self: super:
 let
   callPackage = super.lib.callPackageWith super;
 in
-{
-  i3pyblocks = callPackage ./pkgs/i3pyblocks.nix {};
+rec {
+  # Define some dependencies that are not package yet in nixpkgs
+  _ = {
+    aionotify = callPackage ./pkgs/aionotify.nix {};
+  };
+
+  i3pyblocks = callPackage ./pkgs/i3pyblocks.nix {
+    extraLibs = with super.python3Packages; [
+      _.aionotify
+      aiohttp
+      i3ipc
+      psutil
+      pulsectl
+    ];
+  };
 }

--- a/pkgs/aionotify.nix
+++ b/pkgs/aionotify.nix
@@ -1,0 +1,24 @@
+{ stdenv, python3Packages, }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "aionotify";
+  version = "0.2.0";
+
+  src = builtins.fetchGit {
+    url = "https://github.com/rbarrois/aionotify";
+    ref = "master";
+    rev = "cc3dea411a15f1781c1c56b45fdf9ce583629db7";
+  };
+
+  checkInputs = with python3Packages; [
+    asynctest
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/rbarrois/i3paionotify";
+    description = "Simple, asyncio-based inotify library for Python";
+    license = licenses.bsd2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.thiagokokada ];
+  };
+}


### PR DESCRIPTION
`mach-nix` is a very nice project, but it makes us very distant from NixOS/nixpkgs. Someday I will probably want to upstream i3pyblocks there, so this is a preparation for it.

However, this only works in `unstable` for now, because:
- `pulsectl` doesn't exist in 20.03
- `i3ipc` exists but the version is too old (needs >2.0)

I could also backport those changes but this will make too much work. So let's wait for now and only merge this after NixOS 20.09 is released.

Some advantages of this change:
- We use the same dependencies as `nixpkgs`, so if someone needs the same dependency for other Python app there is no duplication
- We can run the tests after packaging
- No more need to wrap the binary, thanks to this patch: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/python-modules/pulsectl/default.nix#L12-L18