### PR TITLE
Remove pytest runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        make tests-with-coverage
+        make all
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,13 @@ jobs:
         python3 -m venv venv
         make dev-install
 
+    - name: Run linters
+      run: |
+        make lint
+
     - name: Test with pytest
       run: |
-        make all
+        make test-coverage
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/Makefile
+++ b/Makefile
@@ -1,38 +1,22 @@
-SRC_PATHS := i3pyblocks tests *.py
 TEST_PATHS := tests
+SRC_PATHS := *.py i3pyblocks $(TEST_PATHS)
 PYTHON := venv/bin/python
-.PHONY: clean dev-install format format-check lint mypy tests tests-with-coverage
+.PHONY: all deps lint \
+	black black-fix clean deps-compile deps-upgrade deps-sync dev-install \
+	isort isort-fix flake8 mypy test test-coverage
 
-all: tests
+all: lint test-coverage
+deps: deps-compile deps-sync
+lint: black isort flake8 mypy
 
-clean:
-	git clean -fxd
-
-tests:
-	$(PYTHON) -m pytest $(TEST_PATHS)
-
-tests-with-coverage:
-	$(PYTHON) -m pytest --cov=i3pyblocks --cov-report=term --cov-report=xml $(TEST_PATHS)
-
-format:
-	$(PYTHON) -m black $(SRC_PATHS)
-
-format-check:
+black:
 	$(PYTHON) -m black --check $(SRC_PATHS)
 
-isort:
-	$(PYTHON) -m isort $(SRC_PATHS)
+black-fix:
+	$(PYTHON) -m black $(SRC_PATHS)
 
-lint:
-	$(PYTHON) -m flake8 $(SRC_PATHS)
-
-mypy:
-	$(PYTHON) -m mypy $(SRC_PATHS)
-
-dev-install:
-	$(PYTHON) -m pip install -r requirements.txt
-
-deps: deps-compile deps-sync
+clean:
+	rm -rf *.egg-info .{mypy,pytest}_cache __pycache__
 
 deps-compile:
 	CUSTOM_COMPILE_COMMAND="make deps-compile"\
@@ -48,3 +32,24 @@ deps-upgrade:
 
 deps-sync:
 	$(PYTHON) -m piptools sync requirements.txt
+
+dev-install:
+	$(PYTHON) -m pip install -r requirements.txt
+
+isort:
+	$(PYTHON) -m isort --check $(SRC_PATHS)
+
+isort-fix:
+	$(PYTHON) -m isort $(SRC_PATHS)
+
+flake8:
+	$(PYTHON) -m flake8 $(SRC_PATHS)
+
+mypy:
+	$(PYTHON) -m mypy $(SRC_PATHS)
+
+test:
+	$(PYTHON) -m pytest $(TEST_PATHS)
+
+test-coverage:
+	$(PYTHON) -m pytest --cov=i3pyblocks --cov-report=term --cov-report=xml $(TEST_PATHS)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,22 +11,21 @@ appdirs==1.4.4            # via black
 async-timeout==3.0.1      # via aiohttp
 asynctest==0.13.0         # via -r requirements/dev.in
 attrs==20.2.0             # via aiohttp, flake8-bugbear, pytest
-black==20.8b1             # via -r requirements/dev.in, pytest-black
+black==20.8b1             # via -r requirements/dev.in
 chardet==3.0.4            # via aiohttp
 click==7.1.2              # via black, pip-tools
 coverage==5.2.1           # via pytest-cov
-filelock==3.0.12          # via pytest-mypy
 flake8-bugbear==20.1.4    # via -r requirements/dev.in
-flake8==3.8.3             # via -r requirements/dev.in, flake8-bugbear, pytest-flake8
+flake8==3.8.3             # via -r requirements/dev.in, flake8-bugbear
 i3ipc==2.2.1              # via i3pyblocks
 idna==2.10                # via yarl
 iniconfig==1.0.1          # via pytest
-isort==5.5.1              # via -r requirements/dev.in, pytest-isort
+isort==5.5.1              # via -r requirements/dev.in
 mccabe==0.6.1             # via flake8
 more-itertools==8.5.0     # via pytest
 multidict==4.7.6          # via aiohttp, yarl
 mypy-extensions==0.4.3    # via black, mypy
-mypy==0.782               # via -r requirements/dev.in, pytest-mypy
+mypy==0.782               # via -r requirements/dev.in
 packaging==20.4           # via pytest
 pathspec==0.8.0           # via black
 pip-tools==5.3.1          # via -r requirements/dev.in
@@ -39,16 +38,12 @@ pyflakes==2.2.0           # via flake8
 pyparsing==2.4.7          # via packaging
 pytest-aiohttp==0.3.0     # via -r requirements/dev.in
 pytest-asyncio==0.14.0    # via -r requirements/dev.in
-pytest-black==0.3.11      # via -r requirements/dev.in
 pytest-cov==2.10.1        # via -r requirements/dev.in
-pytest-flake8==1.0.6      # via -r requirements/dev.in
-pytest-isort==1.2.0       # via -r requirements/dev.in
-pytest-mypy==0.7.0        # via -r requirements/dev.in
-pytest==6.0.1             # via -r requirements/dev.in, pytest-aiohttp, pytest-asyncio, pytest-black, pytest-cov, pytest-flake8, pytest-mypy
+pytest==6.0.1             # via -r requirements/dev.in, pytest-aiohttp, pytest-asyncio, pytest-cov
 python-xlib==0.27         # via i3ipc
 regex==2020.7.14          # via black
 six==1.15.0               # via packaging, pip-tools, python-xlib
-toml==0.10.1              # via black, pytest, pytest-black
+toml==0.10.1              # via black, pytest
 typed-ast==1.4.1          # via black, mypy
 typing-extensions==3.7.4.3  # via black, mypy
 yarl==1.5.1               # via aiohttp

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -8,8 +8,4 @@ pip-tools
 pytest
 pytest-aiohttp
 pytest-asyncio
-pytest-black
 pytest-cov
-pytest-flake8
-pytest-isort
-pytest-mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,4 +19,4 @@ line_length=88
 src_paths=i3pyblocks,test
 
 [tool:pytest]
-addopts=-vvv -rxs --mypy-ignore-missing-imports --isort --black --flake8 --disable-warnings
+addopts=-vvv -rxs --disable-warnings


### PR DESCRIPTION
Leave only what we actually need for tests, and run linters and mypy using their own command lines. For two reasons:

- I was already bitten by linters/mypy passing in pytest but when running manually they failed
- There is more control. If I want to only run tests or only linters now I can do this easier