### PR TITLE
Convert docstrings from Google to Sphinx format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ PYTHON := venv/bin/python
 all: lint test-coverage
 deps: deps-compile deps-sync
 lint: black isort flake8 mypy
+lint-fix: black-fix isort-fix
 
 black:
 	$(PYTHON) -m black --check $(SRC_PATHS)

--- a/i3pyblocks/blocks/aiohttp.py
+++ b/i3pyblocks/blocks/aiohttp.py
@@ -10,14 +10,14 @@ until the end of the HTTP request. ``aiohttp`` fits this task very well.
 PollingRequestBlock is based on ``PollingBlock`` since the idea of this Block
 is to be used for things like weather updates, for example::
 
-  PollingRequestBlock("https://wttr.in/?format=%c+%t")
+    PollingRequestBlock("https://wttr.in/?format=%c+%t")
 
 But more advanced Blocks could update in response for a Webhook or a system
 event (for example, a network change could trigger a request to get external
 IP).
 
 .. _aiohttp:
-  https://github.com/aio-libs/aiohttp
+    https://github.com/aio-libs/aiohttp
 """
 
 import asyncio
@@ -36,44 +36,44 @@ async def text_callback(resp: aiohttp.ClientResponse) -> str:
     Mostly useful for endpoints that returns just text on its output. Some
     examples::
 
-      $ curl ifconfig.me/ip
-      123.123.123.123
-      $ curl 'wttr.in/?format=%t'
-      +31°C
+        $ curl ifconfig.me/ip
+        123.123.123.123
+        $ curl 'wttr.in/?format=%t'
+        +31°C
     """
     return await resp.text()
 
 
 class PollingRequestBlock(blocks.PollingBlock):
-    """Block that shows result of a periodic HTTP request.
+    r"""Block that shows result of a periodic HTTP request.
 
     This Block continuously request a specified endpoint and shows the result
     and status code of the request in i3bar.
 
-    Args:
-      format:
-        Format string showed after a successful request. Supports both
-        ``{response}`` and ``{status}`` placeholders.
-      format_error:
-        Format string showed in case of an error in request.
-      request_opts:
-        A Dictable of options passed directly to the ``request()`` method
-        in ``aiohttp``. The list of available parameters is `aiohttp docs`_.
-      response_callback:
-        A function that will be called after the response is made to format
-        the result. For example, consider an endpoiint that returns the JSON
-        ``{"hello": "world"}``. We could format its output using::
+    :param format: Format string showed after a successful request. Supports
+        both ``{response}`` and ``{status}`` placeholders.
 
-          def json_callback(resp):
-              j = await resp.json()
-              return f"Hello {j['hello']}"
+    :param format_error: Format string showed in case of an error in request.
+
+    :param request_opts: A Dictable of options passed directly to the
+        ``request()`` method in ``aiohttp``. The list of available parameters
+        is `aiohttp docs`_.
+
+    :param response_callback: A function that will be called after the response
+        is made to format the result. For example, consider an endpoiint that
+        returns the JSON ``{"hello": "world"}``. We could format its output
+        using::
+
+            def json_callback(resp):
+                j = await resp.json()
+                return f"Hello {j['hello']}"
 
         This function would result in ``Hello world`` on ``{response}``
         placeholder.
-      sleep:
-        Sleep in seconds between each call to ``run()``.
-      **kwargs:
-        Extra arguments to be passed to ``PollingBlock`` class.
+
+    :param sleep: Sleep in seconds between each call to ``run()``.
+
+    :param \*\*kwargs: Extra arguments to be passed to ``PollingBlock`` class.
 
     .. _aiohttp docs:
       https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientSession.request

--- a/i3pyblocks/blocks/aionotify.py
+++ b/i3pyblocks/blocks/aionotify.py
@@ -10,9 +10,9 @@ For an example implementation, take BacklightBlock. It watches for changes in
 changed, this Block is updated.
 
 .. _aionotify:
-  https://github.com/rbarrois/aionotify
+    https://github.com/rbarrois/aionotify
 .. _inotify:
-  https://en.wikipedia.org/wiki/Inotify
+    https://en.wikipedia.org/wiki/Inotify
 """
 
 
@@ -29,7 +29,7 @@ from i3pyblocks._internal import utils
 
 
 class FileWatcherBlock(blocks.Block):
-    """File watcher Block.
+    r"""File watcher Block.
 
     A highly efficient Block to watch for events that happen in a file.
 
@@ -39,12 +39,11 @@ class FileWatcherBlock(blocks.Block):
     You must not instantiate this class directly, instead you should
     subclass it and implement ``run()`` method first.
 
-    Args:
-      path:
-        The file path to watch for events.
-      flags:
-        The modification flags to be watched. A list of flags can be found
-        `in aionotify repo`_. Multiple flags can be passed to, for example::
+    :param path: The file path to watch for events.
+
+    :param flags: The modification flags to be watched. A list of flags can be
+        found `in aionotify repo`_. Multiple flags can be passed to, for
+        example::
 
             from aionotify import Flags
 
@@ -52,17 +51,18 @@ class FileWatcherBlock(blocks.Block):
                 path="/some/path",
                 flags=Flags.MODIFY | Flags.CREATE,
             )
-      format_file_not_found:
-        Format string to shown when the file in passed in ``path`` is not
-        found.
-      **kwargs:
-        Extra arguments to be passed to ``Block`` class.
 
-    See Also:
-      ``Block()`` arguments.
+    :param format_file_not_found: Format string to shown when the file in passed
+        in ``path`` is not found.
+
+    :param \*\*kwargs: Extra arguments to be passed to ``Block`` class.
+
+    .. seealso::
+
+        ``Block()`` arguments.
 
     .. _in aionotify repo:
-      https://github.com/rbarrois/aionotify/blob/master/aionotify/enums.py
+        https://github.com/rbarrois/aionotify/blob/master/aionotify/enums.py
     """
 
     def __init__(
@@ -122,36 +122,35 @@ class FileWatcherBlock(blocks.Block):
 
 
 class BacklightBlock(FileWatcherBlock):
-    """Backlight Block.
+    r"""Backlight Block.
 
     Based on `sysfs backlight interface`_.
 
-    Args:
-      format:
-        Format string to shown. Supports the following placeholders:
+    :param format: Format string to shown. Supports the following placeholders:
 
           - ``{brightness}``: Current brightness of display
           - ``{max_brightness}``: Max brightness supported by display
           - ``{percent}``: Percentage between current and max display
             brightness
-      base_path:
-        The path where available backlights will be searched.
-      device_glob:
-        `File glob`_ that will be used to search the device inside the
-        ``base_path``. By default it tries to find anything, but if for
-        some reason you want a specific device you can just use
+
+    :param base_path: The path where available backlights will be searched.
+
+    :param device_glob: `File glob`_ that will be used to search the device
+        inside the ``base_path``. By default it tries to find anything, but if
+        for some reason you want a specific device you can just use
         ``device_name`` here instead.
-      command_on_click:
-        Dictable with commands to be called when the user interacts with mouse
-        inside this block. Can be useful to adjust the backlight using scroll,
-        for example.
-      **kwargs:
-        Extra arguments to be passed to ``FileWatcherBlock`` class.
+
+    :param command_on_click: Dictable with commands to be called when the user
+        interacts with mouse inside this block. Can be useful to adjust the
+        backlight using scroll, for example.
+
+    :param \*\*kwargs: Extra arguments to be passed to ``FileWatcherBlock``
+        class.
 
     .. _sysfs backlight interface:
-      https://www.kernel.org/doc/Documentation/ABI/stable/sysfs-class-backlight
+        https://www.kernel.org/doc/Documentation/ABI/stable/sysfs-class-backlight
     .. _File glob:
-      https://docs.python.org/3/library/glob.html
+        https://docs.python.org/3/library/glob.html
     """
 
     def __init__(

--- a/i3pyblocks/blocks/base.py
+++ b/i3pyblocks/blocks/base.py
@@ -27,19 +27,18 @@ class Block(metaclass=abc.ABCMeta):
     It should not be used directly, instead it should be derivated and its
     abstract methods should be implemented.
 
-    Keyword Args:
-      block_name:
-        Allows you to set a custom internal representation for the class.
-        This should only be useful if you need to differentiate between
-        multiple instances of the same module in a consistent way (i.e.:
-        you can't rely on something random like the `Module.id`).
-        If not passed this will use by default the string representation
-        of the class name.
-      default_state:
-        Defines the default state of the Block, that is, the value that will
-        be shown unless the state is updated by Block's `update_state()` method.
-        For example, let's say you want a block that has a permanent green
-        background (unless overriden), so you can do something like::
+    :param block_name: Allows you to set a custom internal representation for
+        the class. This should only be useful if you need to differentiate
+        between multiple instances of the same module in a consistent way
+        (i.e.: you can't rely on something random like the ``Module.id``).
+        If not passed this will use by default the string representation of
+        the class name.
+
+    :param default_state: Defines the default state of the Block, that is, the
+        value that will be shown unless the state is updated by Block's
+        ``update_state()`` method. For example, let's say you want a block that
+        has a permanent green background (unless overriden), so you can do
+        something like::
 
             block_instance = Block(
                 default_state={
@@ -50,9 +49,10 @@ class Block(metaclass=abc.ABCMeta):
         And all calls to `result()` will have ``background == "#008000"``,
         unless overriden by ``update_status()`` with a different value.
 
-    See Also:
-      For details about each of the keys available in ``default_state``, see
-      ``update_state()`` documentation.
+    .. seealso::
+
+        For details about each of the keys available in ``default_state``, see
+        ``update_state()`` documentation.
     """
 
     def __init__(
@@ -115,59 +115,59 @@ class Block(metaclass=abc.ABCMeta):
         since they're mapped directly from it (so a ``full_text="foo"`` results
         in a ``{"full_text": "foo"}`` in the Block's output).
 
-        Args:
-          full_text:
-            The full_text will be displayed by i3bar on the status line. This
-            is the only required parameter. If full_text is an empty string, the
-            block will be skipped.
-          short_text:
-            It will be used in case the status line needs to be shortened because
-            it uses more space than your screen provides.
-          color:
-            To make the current state of the information easy to spot, colors can
-            be used. Colors are specified in hex (like in HTML), starting with a
-            leading hash sign. For example, #ff0000 means red.
-          background:
-            Overrides the background color for this particular block.
-          border:
-            Overrides the border color for this particular block.
-          border_top:
-            Defines the width (in pixels) of the top border of this block.
-            Defaults to 1.
-          border_right:
-            Defines the width (in pixels) of the right border of this block.
-            Defaults to 1.
-          border_bottom:
-            Defines the width (in pixels) of the bottom border of this block.
-            Defaults to 1.
-          border_left:
-            Defines the width (in pixels) of the left border of this block.
-            Defaults to 1.
-          min_width:
-            The minimum width (in pixels) of the block. If the content of the
-            full_text key take less space than the specified min_width, the
-            block will be padded to the left and/or the right side, according
-            to the align key.
-          align:
-            Align text on the center, right or left (default) of the block,
-            when the minimum width of the latter, specified by the min_width
-            key, is not reached.
-          urgent:
-            A boolean which specifies whether the current value is urgent.
-          separator:
-            A boolean which specifies whether a separator line should be
-            drawn after this block. The default is true, meaning the separator
-            line will be drawn.
-          separator_block_width:
-            The amount of pixels to leave blank after the block. In the middle
-            of this gap, a separator line will be drawn unless separator is
-            disabled.
-          markup:
-            A string that indicates how the text of the block should be parsed.
-            Pango markup only works if you use a pango font.
+        :param full_text: The full_text will be displayed by i3bar on the status
+            line. This is the only required parameter. If full_text is an empty
+            string, the block will be skipped.
+
+        :param short_text: It will be used in case the status line needs to be
+            shortened because it uses more space than your screen provides.
+
+        :param color: To make the current state of the information easy to spot,
+            colors can be used. Colors are specified in hex (like in HTML),
+            starting with a leading hash sign. For example, #ff0000 means red.
+
+        :param background: Overrides the background color for this particular
+            block.
+
+        :param border: Overrides the border color for this particular block.
+
+        :param border_top: Defines the width (in pixels) of the top border of
+            this block. Defaults to 1.
+
+        :param border_right: Defines the width (in pixels) of the right border
+            of this block. Defaults to 1.
+
+        :param border_bottom: Defines the width (in pixels) of the bottom border
+            of this block. Defaults to 1.
+
+        :param border_left: Defines the width (in pixels) of the left border of
+            this block. Defaults to 1.
+
+        :param min_width: The minimum width (in pixels) of the block. If the
+            content of the full_text key take less space than the specified
+            min_width, the block will be padded to the left and/or the right
+            side, according to the align key.
+
+        :param align: Align text on the center, right or left (default) of the
+            block, when the minimum width of the latter, specified by the
+            min_width key, is not reached.
+
+        :param urgent: A boolean which specifies whether the current value is
+            urgent.
+
+        :param separator: A boolean which specifies whether a separator line
+            should be drawn after this block. The default is true, meaning the
+            separator line will be drawn.
+
+        :param separator_block_width: The amount of pixels to leave blank after
+            the block. In the middle of this gap, a separator line will be
+            drawn unless separator is disabled.
+
+        :param markup: A string that indicates how the text of the block should
+            be parsed. Pango markup only works if you use a pango font.
 
         .. _i3bar's protocol specification:
-          https://i3wm.org/docs/i3bar-protocol.html#_blocks_in_detail
+            https://i3wm.org/docs/i3bar-protocol.html#_blocks_in_detail
         """
         self._state = utils.non_nullable_dict(
             full_text=full_text,
@@ -193,14 +193,13 @@ class Block(metaclass=abc.ABCMeta):
         This will combine both the default state and the current state to
         generate the current state of the Block.
 
-        Returns:
-          A ``i3pyblocks.types.Result`` map, ready to be converted to JSON.
-          For example::
+        :returns: A ``i3pyblocks.types.Result`` map, ready to be converted to
+            JSON. For example::
 
-            {
-               "full_text": "Some funny text",
-               "background": "#FF0000",
-            }
+                {
+                    "full_text": "Some funny text",
+                    "background": "#FF0000",
+                }
         """
         return {**self._default_state, **self._state}
 
@@ -225,8 +224,9 @@ class Block(metaclass=abc.ABCMeta):
         The parameters of this method is passed as-is to Block's
         ``update_state()``.
 
-        See Also:
-          ``Block.update_state()`` arguments.
+        .. seealso::
+
+            ``Block.update_state()`` arguments.
         """
         self.update_state(*args, **kwargs)
         self.push_update()
@@ -244,8 +244,9 @@ class Block(metaclass=abc.ABCMeta):
         The parameters of this method is passed as-is to Block's
         ``update_state()``.
 
-        See Also:
-          ``Block.update_state()`` arguments.
+        .. seealso:
+
+            ``Block.update_state()`` arguments.
         """
         self.update(*args, **kwargs)
         self.frozen = True
@@ -261,10 +262,8 @@ class Block(metaclass=abc.ABCMeta):
         ``await super().setup(queue=queue)`` after your code to prepare your
         Block for updates.
 
-        Args:
-          queue:
-            ``asyncio.Queue`` instance that will be used to notify updates
-            from this Block.
+        :param queue: ``asyncio.Queue`` instance that will be used to notify
+            updates from this Block.
         """
         self.update_queue = queue
         self.frozen = False
@@ -286,33 +285,32 @@ class Block(metaclass=abc.ABCMeta):
         Each of this method arguments is from `i3bar's protocol specification`_,
         since they're mapped directly (so a ``{"x": 1}`` results in a ``x=1``).
 
-        Keyword Args:
-          x:
-            X11 root window coordinates where the click occurred.
-          y:
-            X11 root window coordinates where the click occurred.
-          button:
-            X11 button ID (for example 1 to 3 for left/middle/right mouse
-            button).
-          relative_x:
-            Coordinates where the click occurred, with respect to the top left
-            corner of the block.
-          relative_y:
-            Coordinates where the click occurred, with respect to the top left
-            corner of the block.
-          width:
-            Width (in px) of the block.
-          height:
-            Height (in px) of the block.
-          modifier:
-            A list of the modifiers active when the click occurred. The
-            order in which modifiers are listed is not guaranteed.
+        :param x: X11 root window coordinates where the click occurred.
 
-        See Also:
-          ``i3pyblocks.types.MouseButton`` has the mapping of the available
-          mouse button IDs.
-          ``i3pyblocks.types.KeyModifier`` has the mapping of the available
-          modifiers.
+        :param y: X11 root window coordinates where the click occurred.
+
+        :param button: X11 button ID (for example 1 to 3 for left/middle/right
+            mouse button).
+
+        :param relative_x: Coordinates where the click occurred, with respect
+            to the top left corner of the block.
+
+        :param relative_y: Coordinates where the click occurred, with respect
+            to the top left corner of the block.
+
+        :param width: Width (in px) of the block.
+
+        :param height: Height (in px) of the block.
+
+        :param modifier: A list of the modifiers active when the click occurred.
+            The order in which modifiers are listed is not guaranteed.
+
+        .. seealso::
+
+            ``i3pyblocks.types.MouseButton`` has the mapping of the available
+            mouse button IDs.
+            ``i3pyblocks.types.KeyModifier`` has the mapping of the available
+            modifiers.
 
         .. i3bar's protocol specification:
           https://i3wm.org/docs/i3bar-protocol.html#_click_events
@@ -322,10 +320,8 @@ class Block(metaclass=abc.ABCMeta):
     async def signal_handler(self, *, sig: signal.Signals) -> None:
         """Callback called when a signal event happens to this Block.
 
-        Keyword Args:
-          sig:
-            Signals enum with the signal that originated this event. This can
-            be used to differentiate between different signals.
+        :param sig: Signals enum with the signal that originated this event.
+            This can be used to differentiate between different signals.
         """
         pass
 
@@ -357,12 +353,11 @@ class PollingBlock(Block):
     You must not instantiate this class directly, instead you should
     subclass it and implement ``run()`` method first.
 
-    Args:
-      sleep:
-        Sleep in seconds between each call to ``run()``.
+    :param sleep: Sleep in seconds between each call to ``run()``.
 
-    See Also:
-      ``Block()`` arguments.
+    .. seealso::
+
+        ``Block()`` arguments.
     """
 
     def __init__(self, sleep: int = 1, **kwargs) -> None:
@@ -422,18 +417,17 @@ class ExecutorBlock(Block):
     You must not instantiate this class directly, instead you should
     subclass it and implement ``run()`` method first.
 
-    Args:
-      executor:
-        An optional `Executor instance`_. If not passed it will use the
-        default one.
+    :param executor: An optional `Executor instance`_. If not passed it will
+        use the default one.
 
-    See also:
-      ``Block()`` arguments.
+    .. seealso::
+
+        ``Block()`` arguments.
 
     .. _executor:
-      https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.run_in_executor
+        https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.run_in_executor
     .. _Executor instance:
-      https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Executor
+        https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Executor
     """
 
     def __init__(self, executor: Optional[Executor] = None, **kwargs) -> None:

--- a/i3pyblocks/blocks/basic.py
+++ b/i3pyblocks/blocks/basic.py
@@ -4,13 +4,13 @@ from i3pyblocks import blocks
 
 
 class TextBlock(blocks.Block):
-    """Block that shows arbitrary text in i3pyblocks.
+    r"""Block that shows arbitrary text in i3pyblocks.
 
-    Args:
-      full_text:
+    :param full_text:
         Text to be shown.
-      **kwargs:
-        Arguments to be passed to ``i3pyblocks.Block.update_state()`` method.
+
+    :param \*\*kwargs: Arguments to be passed to
+        ``i3pyblocks.Block.update_state()`` method.
     """
 
     def __init__(self, full_text: str, **kwargs) -> None:

--- a/i3pyblocks/blocks/datetime.py
+++ b/i3pyblocks/blocks/datetime.py
@@ -1,7 +1,7 @@
 """Blocks based on `datetime`_.
 
 .. _datetime:
-  https://docs.python.org/3/library/datetime.html
+    https://docs.python.org/3/library/datetime.html
 """
 
 from datetime import datetime
@@ -10,25 +10,25 @@ from i3pyblocks import blocks
 
 
 class DateTimeBlock(blocks.PollingBlock):
-    """Block that shows date and time for current location.
+    r"""Block that shows date and time for current location.
 
     This blocks alternates between Time and Date display by clicks in the
     Block. Keep in mind that ``format_date`` and ``format_time`` names are
     arbitrary and both formats have capacity to display both date and time.
 
-    Args:
-      format_date:
-        Format string when showing date. Uses `strftime`_ placeholders.
-      format_time:
-        Format string when showing time. Uses `strftime`_ placeholders.
-      sleep:
-        Sleep in seconds between each call to ``run()``. If you're not showing
-        seconds in this block it makes sense to increase this value.
-      **kwargs:
-        Extra arguments to be passed to ``PollingBlock`` class.
+    :param format_date: Format string when showing date. Uses `strftime`_
+        placeholders.
+
+    :param format_time: Format string when showing time. Uses `strftime`_
+        placeholders.
+
+    :param sleep: Sleep in seconds between each call to ``run()``. If you're
+        not showing seconds in this block it makes sense to increase this value.
+
+    :param \*\*kwargs: Extra arguments to be passed to ``PollingBlock`` class.
 
     .. _strftime:
-      https://strftime.org/
+        https://strftime.org/
     """
 
     def __init__(

--- a/i3pyblocks/blocks/i3ipc.py
+++ b/i3pyblocks/blocks/i3ipc.py
@@ -7,7 +7,7 @@ Since it uses a publish/subscribe mechanism, it should be highly efficient,
 only updating when it is actually needed.
 
 .. _i3ipc:
-  https://github.com/altdesktop/i3ipc-python
+    https://github.com/altdesktop/i3ipc-python
 """
 
 import i3ipc
@@ -17,13 +17,12 @@ from i3pyblocks import blocks, core
 
 
 class WindowTitleBlock(blocks.Block):
-    """Block that shows the current window title.
+    r"""Block that shows the current window title.
 
-    Args:
-      format:
-        Format string to shown. Supports ``{window_title}`` placeholder.
-      **kwargs:
-        Extra arguments to be passed to ``Block`` class.
+    :param format: Format string to shown. Supports ``{window_title}``
+        placeholder.
+
+    :param \*\*kwargs: Extra arguments to be passed to ``Block`` class.
     """
 
     def __init__(

--- a/i3pyblocks/blocks/psutil.py
+++ b/i3pyblocks/blocks/psutil.py
@@ -15,7 +15,7 @@ can't just update when memory usage increase/decrease or we would use too much
 resources for it).
 
 .. _psutil:
-  https://github.com/giampaolo/psutil
+    https://github.com/giampaolo/psutil
 """
 
 import datetime
@@ -34,32 +34,30 @@ _CPU_COUNT = psutil.cpu_count()
 
 
 class CpuPercentBlock(blocks.PollingBlock):
-    """Block that shows the current CPU percentage.
+    r"""Block that shows the current CPU percentage.
 
-    Args:
-      format:
-        Format string to shown. Supports both ``{percent}`` and ``{icon}``
-        placeholders.
-      colors:
-        A Dictable that represents the color that will be shown in each CPU
-        interval. For example::
+    :param format: Format string to shown. Supports both ``{percent}`` and
+        ``{icon}`` placeholders.
 
-          {
-             0: "000000",
-             10: "#FF0000",
-             50: "#FFFFFF",
-          }
+    :param colors: A Dictable that represents the color that will be shown in
+        each CPU interval. For example::
+
+            {
+                0: "000000",
+                10: "#FF0000",
+                50: "#FFFFFF",
+            }
 
         When the CPU % is between [0, 10) the color is set to "000000", from
         [10, 50) is set to "FF0000" and from 50 and beyond it is "#FFFFFF".
-      icons:
-        Similar to ``colors``, but for icons. Can be used to create a graphic
-        representation of the CPU %. Only displayed when ``format`` includes
-        ``{icon}`` placeholder.
-      sleep:
-        Sleep in seconds between each call to ``run()``.
-      **kwargs:
-        Extra arguments to be passed to ``PollingBlock`` class.
+
+    :param icons: Similar to ``colors``, but for icons. Can be used to create a
+        graphic representation of the CPU %. Only displayed when ``format``
+        includes ``{icon}`` placeholder.
+
+    :param sleep: Sleep in seconds between each call to ``run()``.
+
+    :param \*\*kwargs: Extra arguments to be passed to ``PollingBlock`` class.
     """
 
     def __init__(
@@ -107,13 +105,11 @@ class CpuPercentBlock(blocks.PollingBlock):
 
 
 class DiskUsageBlock(blocks.PollingBlock):
-    """Block that shows the current disk usage for path.
+    r"""Block that shows the current disk usage for path.
 
-    Args:
-      path:
-        Path to the disk to shown.
-      format:
-        Format string to shown. Supports the following placeholders:
+    :param path: Path to the disk to shown.
+
+    :param format: Format string to shown. Supports the following placeholders:
 
         - ``{path}``: Disk path, for example: ``/mnt/backup``
         - ``{short_path}``: Disk path, but only show the first letter of each
@@ -123,29 +119,29 @@ class DiskUsageBlock(blocks.PollingBlock):
         - ``{free}``: Disk free size
         - ``{percent}``: Disk usage in percentage
         - ``{icon}``: Show disk usage percentage in icon representation
-      colors:
-        A Dictable that represents the color that will be shown in each disk
-        usage in percentage interval. For example::
 
-          {
-             0: "000000",
-             10: "#FF0000",
-             50: "#FFFFFF",
-          }
+    :param colors: A Dictable that represents the color that will be shown in
+        each disk usage in percentage interval. For example::
+
+            {
+                0: "000000",
+                10: "#FF0000",
+                50: "#FFFFFF",
+            }
 
         When the disk % is between [0, 10) the color is set to "000000", from
         [10, 50) is set to "FF0000" and from 50 and beyond it is "#FFFFFF".
-      icons:
-        Similar to ``colors``, but for icons. Can be used to create a graphic
-        representation of the disk %. Only displayed when ``format`` includes
-        ``{icon}`` placeholder.
-      divisor:
-        Divisor used for all size reportings for this Block. For example, using
-        ``1024 ** 1024`` here makes all sizes return in MiB.
-      sleep:
-        Sleep in seconds between each call to ``run()``.
-      **kwargs:
-        Extra arguments to be passed to ``PollingBlock`` class.
+
+    :param icons: Similar to ``colors``, but for icons. Can be used to create a
+        graphic representation of the disk %. Only displayed when ``format``
+        includes ``{icon}`` placeholder.
+
+    :param divisor: Divisor used for all size reportings for this Block. For
+        example, using ``1024 ** 1024`` here makes all sizes return in MiB.
+
+    :param sleep: Sleep in seconds between each call to ``run()``.
+
+    :param \*\*kwargs: Extra arguments to be passed to ``PollingBlock`` class.
     """
 
     def __init__(
@@ -209,21 +205,19 @@ class DiskUsageBlock(blocks.PollingBlock):
 
 
 class LoadAvgBlock(blocks.PollingBlock):
-    """Block that shows the current load average, in the last 1, 5 or 15 minutes.
+    r"""Block that shows the current load average, in the last 1, 5 or 15 minutes.
 
-    Args:
-      format:
-        Format string to shown. Supports the ``{load1}``, ``{load5}`` and
-        ``{load15}`` placeholders.
-      colors:
-        A Dictable that represents the color that will be shown in each load1
-        interval. For example::
+    :param format: Format string to shown. Supports the ``{load1}``, ``{load5}``
+        and ``{load15}`` placeholders.
 
-          {
-             0: "000000",
-             2: "#FF0000",
-             4: "#FFFFFF",
-          }
+    :param colors: A Dictable that represents the color that will be shown in
+        each load1 interval. For example::
+
+            {
+                0: "000000",
+                2: "#FF0000",
+                4: "#FFFFFF",
+            }
 
         When the load1 is between [0, 2) the color is set to "000000", from
         [2, 4) is set to "FF0000" and from 4 and beyond it is "#FFFFFF".
@@ -232,10 +226,10 @@ class LoadAvgBlock(blocks.PollingBlock):
         logical CPUs in the system, by default this block returns
         ``types.Color.WARN`` for ``load1 == <cpu count> / 2`` and
         ``types.Color.URGENT`` for ``load1 == <cpu count>``.
-      sleep:
-        Sleep in seconds between each call to ``run()``.
-      **kwargs:
-        Extra arguments to be passed to ``PollingBlock`` class.
+
+    :param sleep: Sleep in seconds between each call to ``run()``.
+
+    :param \*\*kwargs: Extra arguments to be passed to ``PollingBlock`` class.
     """
 
     def __init__(
@@ -267,12 +261,10 @@ class LoadAvgBlock(blocks.PollingBlock):
 
 
 class NetworkSpeedBlock(blocks.PollingBlock):
-    """Block that shows the current network speed for the connect interface.
+    r"""Block that shows the current network speed for the connect interface.
 
-    Args:
-      format_up:
-        Format string to shown when there is at least one connected interface.
-        Supports the following placeholders:
+    :param format_up: Format string to shown when there is at least one
+        connected interface. Supports the following placeholders:
 
         - ``{interface}``: Interface name, for example: ``eno1``
         - ``{upload}``: Upload speed
@@ -281,26 +273,30 @@ class NetworkSpeedBlock(blocks.PollingBlock):
         Since upload/download speeds varies greatly during usage, this module
         automatically finds the most compact speed representation. So instead
         of showing ``1500K`` it will show ``1.5M``, for example.
-      colors:
-        A Dictable that represents the color that will be shown in each load1
-        interval. For example::
 
-          {
-             0: "000000",
-             2 * types.IECUnit.MIB: "#FF0000",
-             4 * types.IECUnit.MIB: "#FFFFFF",
-          }
+    :param format_down: Format string to shown when there is no connected
+        interface.
+
+    :param colors: A Dictable that represents the color that will be shown in
+        each load1 interval. For example::
+
+            {
+                0: "000000",
+                2 * types.IECUnit.MIB: "#FF0000",
+                4 * types.IECUnit.MIB: "#FFFFFF",
+            }
 
         When the network speed is between [0, 2) MiB the color is set to
         "000000", from [2, 4) is set to "FF0000" and from 4 and beyond it is
         "#FFFFFF".
-      interface_regex:
-        Regex for which interfaces to use. By default it already includes the
-        most common ones and excludes things like ``lo`` (loopback interface).
-      sleep:
-        Sleep in seconds between each call to ``run()``.
-      **kwargs:
-        Extra arguments to be passed to ``PollingBlock`` class.
+
+    :param interface_regex: Regex for which interfaces to use. By default it
+         already includes the most common ones and excludes things like ``lo``
+         (loopback interface).
+
+    :param sleep: Sleep in seconds between each call to ``run()``.
+
+    :param \*\*kwargs: Extra arguments to be passed to ``PollingBlock`` class.
     """
 
     def __init__(
@@ -374,45 +370,42 @@ class NetworkSpeedBlock(blocks.PollingBlock):
 
 
 class SensorsBatteryBlock(blocks.PollingBlock):
-    """Block that shows battery information.
+    r"""Block that shows battery information.
 
-    Args:
-      format_plugged:
-        Format string to shown when the battery is plugged (charging).
-        Support the following placeholders:
+    :param format_plugged: format string to shown when the battery is plugged
+        (charging). support the following placeholders:
 
-        - ``{percent}``: Battery capacity in percentage
-        - ``{remaining_time}``: Battery remaining time
-        - ``{icon}``: Show battery capacity percentage in icon representation
-      format_unplugged:
-        Format string to shown when the battery is unplugged (discharging).
-        Supports the same placeholders as ``format_unplugged``.
-      format_unknown:
-        Format string to shown when the battery is an unknown state.
-        Supports the same placeholders as ``format_unplugged``.
-      format_no_battery:
-        Format string to shown when no battery is detected.
-      colors:
-        A Dictable that represents the color that will be shown in each battery
-        percentage interval. For example::
+        - ``{percent}``: battery capacity in percentage
+        - ``{remaining_time}``: battery remaining time
+        - ``{icon}``: show battery capacity percentage in icon representation
 
-          {
-             0: "000000",
-             10: "#FF0000",
-             25: "#FFFFFF",
-          }
+    :param format_unplugged: Format string to shown when the battery is unplugged
+        (discharging). Supports the same placeholders as ``format_unplugged``.
+
+    :param format_unknown: Format string to shown when the battery is an unknown
+        state. Supports the same placeholders as ``format_unplugged``.
+
+    :param format_no_battery: Format string to shown when no battery is detected.
+
+    :param colors: A Dictable that represents the color that will be shown in
+        each battery percentage interval. For example::
+
+            {
+                0: "000000",
+                10: "#FF0000",
+                25: "#FFFFFF",
+            }
 
         When the battery percentage is between [0, 10) % the color is set to
         "000000", from [10, 25) is set to "FF0000" and from 25 and beyond it is
         "#FFFFFF".
-      icons:
-        Similar to ``colors``, but for icons. Can be used to create a graphic
-        representation of the battery %. Only displayed when ``format`` includes
-        ``{icon}`` placeholder.
-      sleep:
-        Sleep in seconds between each call to ``run()``.
-      **kwargs:
-        Extra arguments to be passed to ``PollingBlock`` class.
+
+    :param icons: Similar to ``colors``, but for icons. Can be used to create a
+        graphic representation of the battery %. Only displayed when ``format``
+        includes ``{icon}`` placeholder.
+
+    :param sleep: Sleep in seconds between each call to ``run()``.
+    :param \*\*kwargs: Extra arguments to be passed to ``PollingBlock`` class.
     """
 
     def __init__(
@@ -482,40 +475,38 @@ class SensorsBatteryBlock(blocks.PollingBlock):
 
 
 class SensorsTemperaturesBlock(blocks.PollingBlock):
-    """Block that shows sensor temperature information.
+    r"""Block that shows sensor temperature information.
 
-    Args:
-      format:
-        Format string to shown. Support the following placeholders:
+    :param format: Format string to shown. Support the following placeholders:
 
         - ``{label}``: Label of the sensor. Architecture specific
         - ``{current}``: Current temperature reported by sensor
         - ``{high}``: Highest temperature reported by sensor
         - ``{critical}``: Critical temperature reported by sensor
         - ``{icon}``: Show sensor temperature in icon representation
-      colors:
-        A Dictable that represents the color that will be shown in each temperature
-        interval. For example::
 
-          {
-             0: "000000",
-             50: "#FF0000",
-             80: "#FFFFFF",
-          }
+    :param colors: A Dictable that represents the color that will be shown in each
+        temperature interval. For example::
+
+            {
+                0: "000000",
+                50: "#FF0000",
+                80: "#FFFFFF",
+            }
 
         When the sensor temperature is between [0, 50) % the color is set to
         "000000", from [50, 80) is set to "FF0000" and from 80 and beyond it is
         "#FFFFFF".
-      icons:
-        Similar to ``colors``, but for icons. Can be used to create a graphic
-        representation of the temperature. Only displayed when ``format``
+
+    :param icons: Similar to ``colors``, but for icons. Can be used to create a
+        graphic representation of the temperature. Only displayed when ``format``
         includes ``{icon}`` placeholder.
-      fahrenheit:
-        Show temperature in in Fahrenheit instead of Celsius.
-      sleep:
-        Sleep in seconds between each call to ``run()``.
-      **kwargs:
-        Extra arguments to be passed to ``PollingBlock`` class.
+
+    :param fahrenheit: Show temperature in in Fahrenheit instead of Celsius.
+
+    :param sleep: Sleep in seconds between each call to ``run()``.
+
+    :param \*\*kwargs: Extra arguments to be passed to ``PollingBlock`` class.
     """
 
     def __init__(
@@ -574,11 +565,9 @@ class SensorsTemperaturesBlock(blocks.PollingBlock):
 
 
 class VirtualMemoryBlock(blocks.PollingBlock):
-    """Block that shows virtual memory information.
+    r"""Block that shows virtual memory information.
 
-    Args:
-      format:
-        Format string to shown. Support the following placeholders:
+    :param format: Format string to shown. Support the following placeholders:
 
         - ``{total}``: Total installed memory
         - ``{available}``: Available memory
@@ -586,30 +575,30 @@ class VirtualMemoryBlock(blocks.PollingBlock):
         - ``{free}``: Free memory
         - ``{percent}``: Percent used memory
         - ``{icon}``: Show memory percent in icon representation
-      colors:
-        A Dictable that represents the color that will be shown in each used
-        memory percentage. For example::
 
-          {
-             0: "000000",
-             50: "#FF0000",
-             80: "#FFFFFF",
-          }
+    :param colors: A Dictable that represents the color that will be shown in
+        each used memory percentage. For example::
+
+            {
+                0: "000000",
+                50: "#FF0000",
+                80: "#FFFFFF",
+            }
 
         When the used memory % is between [0, 50) % the color is set to
         "000000", from [50, 80) is set to "FF0000" and from 80 and beyond it is
         "#FFFFFF".
-      divisor:
-        Divisor used for all size reportings for this Block. For example, using
-        ``1024 ** 1024`` here makes all sizes return in MiB.
-      icons:
-        Similar to ``colors``, but for icons. Can be used to create a graphic
-        representation of the used memory. Only displayed when ``format``
+
+    :param divisor: Divisor used for all size reportings for this Block. For
+        example, using ``1024 ** 1024`` here makes all sizes return in MiB.
+
+    :param icons: Similar to ``colors``, but for icons. Can be used to create a
+        graphic representation of the used memory. Only displayed when ``format``
         includes ``{icon}`` placeholder.
-      sleep:
-        Sleep in seconds between each call to ``run()``.
-      **kwargs:
-        Extra arguments to be passed to ``PollingBlock`` class.
+
+    :param sleep: Sleep in seconds between each call to ``run()``.
+
+    :param \*\*kwargs: Extra arguments to be passed to ``PollingBlock`` class.
     """
 
     def __init__(

--- a/i3pyblocks/blocks/pulsectl.py
+++ b/i3pyblocks/blocks/pulsectl.py
@@ -10,12 +10,12 @@ pretty efficient since it react to events from PulseAudio itself.
 Needs PulseAudio installed in your computer, or you will receive the following
 error when trying to run this module::
 
-  OSError: libpulse.so.0: cannot open shared object file: No such file or directory
+    OSError: libpulse.so.0: cannot open shared object file: No such file or directory
 
 .. _pulsectl:
-  https://github.com/mk-fg/python-pulse-control
+    https://github.com/mk-fg/python-pulse-control
 .. _PulseAudio:
-  https://www.freedesktop.org/wiki/Software/PulseAudio/
+    https://www.freedesktop.org/wiki/Software/PulseAudio/
 """
 
 import subprocess
@@ -31,7 +31,7 @@ from i3pyblocks._internal import utils
 
 # Based on: https://git.io/fjbHp
 class PulseAudioBlock(blocks.ExecutorBlock):
-    """Block that shows volume and other info from default PulseAudio sink.
+    r"""Block that shows volume and other info from default PulseAudio sink.
 
     This Block shows the volume of the current default PulseAudio sink, and
     also includes a ``click_handler()`` allowing you to mute the default sink
@@ -39,35 +39,33 @@ class PulseAudioBlock(blocks.ExecutorBlock):
     It will also open a program on the left click, by default it calls the
     `pavucontrol`_ but this is configurable.
 
-    Args:
-      format:
-        Format string showed when the audio sink is not mute. Supports both
-        ``{volume}`` and ``{icon}`` placeholders.
-      format_mute:
-        Format string showing when the audio sink is mute. It will be shown
-        with ``color_mute`` set.
-      colors:
-        A Dictable that represents the color that will be shown in each volume
-        interval. For example::
+    :param format: Format string showed when the audio sink is not mute. Supports
+        both ``{volume}`` and ``{icon}`` placeholders.
 
-          {
-             0: "000000",
-             10: "#FF0000",
-             50: "#FFFFFF",
-          }
+    :param format_mute: Format string showing when the audio sink is mute. It
+        will be shown with ``color_mute`` set.
+
+    :param colors: A Dictable that represents the color that will be shown in
+        each volume interval. For example::
+
+            {
+                0: "000000",
+                10: "#FF0000",
+                50: "#FFFFFF",
+            }
 
         When the volume is between [0, 10) the color is set to "000000", from
         [10, 50) is set to "FF0000" and from 50 and beyond it is "#FFFFFF".
-      color_mute:
-        Color used when the sound is mute.
-      icons:
-        Similar to ``colors``, but for icons. Can be used to create a graphic
-        representation of the volume. Only displayed when ``format`` includes
-        ``{icon}`` placeholder.
-      command:
-        Program to run when this block is right clicked.
-      **kwargs:
-        Extra arguments to be passed to ``BlockExecutor`` class.
+
+    :param color_mute: Color used when the sound is mute.
+
+    :param icons: Similar to ``colors``, but for icons. Can be used to create a
+        graphic representation of the volume. Only displayed when ``format``
+        includes ``{icon}`` placeholder.
+
+    :param command: Program to run when this block is right clicked.
+
+    :param \*\*kwargs: Extra arguments to be passed to ``BlockExecutor`` class.
 
     .. _pavucontrol:
       https://freedesktop.org/software/pulseaudio/pavucontrol/
@@ -181,10 +179,8 @@ class PulseAudioBlock(blocks.ExecutorBlock):
     def change_volume(self, volume: float):
         """Change volume of the current PulseAudio sink.
 
-        Args:
-          volume:
-            Float to be increased/decreased relative to the current volume.
-            To decrease the volume use a negative value.
+        :param volume: Float to be increased/decreased relative to the current
+            volume. To decrease the volume use a negative value.
         """
         # TODO: Use self.pulse instead of our own Pulse instance here
         # Using self.pulse.volume_change_all_chans() may cause a deadlock

--- a/i3pyblocks/blocks/subprocess.py
+++ b/i3pyblocks/blocks/subprocess.py
@@ -9,7 +9,7 @@ There is some alternatives that to try in the future, for example using inotify
 or dbus based approaches.
 
 .. _asyncio.subprocess:
-  https://docs.python.org/3/library/asyncio-subprocess.html
+    https://docs.python.org/3/library/asyncio-subprocess.html
 """
 from asyncio import subprocess
 
@@ -18,21 +18,20 @@ from i3pyblocks._internal import utils
 
 
 class ShellBlock(blocks.PollingBlock):
-    """Block that shows the result of a command running in shell.
+    r"""Block that shows the result of a command running in shell.
 
-    Args:
-      command:
-        Command to be run. This will be parsed by shell, so it can also be
-        multiple arbitrary commands separated by newlines, or multiple
+    :param command: Command to be run. This will be parsed by shell, so it can
+        also be multiple arbitrary commands separated by newlines, or multiple
         commands connected by pipes.
-      format:
-        Format string to shown. Supports both ``{output}`` (stdout) and
-        ``{output_err}`` (stderr) placeholders.
-      command_on_click:
-        Dictable with commands to be called when the user interacts with mouse
-        inside this block. After running this Block will be updated. Can be
-        useful to change the keyboard layout for example.
-      **kwargs:
+
+    :param format: Format string to shown. Supports both ``{output}`` (stdout)
+        and ``{output_err}`` (stderr) placeholders.
+
+    :param command_on_click: Dictable with commands to be called when the user
+        interacts with mouse inside this block. After running this Block will
+        be updated. Can be useful to change the keyboard layout for example.
+
+    :param \*\*kwargs:
         Extra arguments to be passed to ``PollingBlock`` class.
     """
 
@@ -85,31 +84,29 @@ class ShellBlock(blocks.PollingBlock):
 
 
 class ToggleBlock(blocks.PollingBlock):
-    """Block that shows a toggle on or off accordingly to command's output.
+    r"""Block that shows a toggle on or off accordingly to command's output.
 
     This block output is determined by ``command_state``. When the command
     outputs something in stdout, this is interpreted as ON, while when the
     command outputs nothing in stdout, this is interpreted as OFF.
 
-    Args:
-      command_state:
-        Command to be run to determine state. This will be parsed by shell,
-        so it can also be multiple arbitrary commands separated by newlines,
-        or multiple commands connected by pipes.
-      command_on:
-        Command to be called when the current state is OFF, so it can be
-        turned to ON.
-      command_off:
-        Command to be called when the current state is ON, so it can be
-        turned to OFF.
-      format_on:
-        Format string to be shown when state is ON.
-      format_off:
-        Format string to be shown when state is OFF.
-      sleep:
-        Sleep in seconds between each call to ``run()``.
-      **kwargs:
-        Extra arguments to be passed to ``PollingBlock`` class.
+    :param command_state: Command to be run to determine state. This will be
+        parsed by shell, so it can also be multiple arbitrary commands
+        separated by newlines, or multiple commands connected by pipes.
+
+    :param command_on: Command to be called when the current state is OFF, so
+        it can be turned to ON.
+
+    :param command_off: Command to be called when the current state is ON, so
+        it can be turned to OFF.
+
+    :param format_on: Format string to be shown when state is ON.
+
+    :param format_off: Format string to be shown when state is OFF.
+
+    :param sleep: Sleep in seconds between each call to ``run()``.
+
+    :param \*\*kwargs: Extra arguments to be passed to ``PollingBlock`` class.
     """
 
     def __init__(

--- a/i3pyblocks/core.py
+++ b/i3pyblocks/core.py
@@ -31,7 +31,7 @@ class Runner:
     possible click events comming from `i3bar`_.
 
     .. _i3bar:
-      https://i3wm.org/docs/i3bar-protocol.html
+        https://i3wm.org/docs/i3bar-protocol.html
     """
 
     def __init__(self) -> None:
@@ -48,36 +48,37 @@ class Runner:
     ) -> None:
         """Registers a list of Unix signals for a Block.
 
-        This will register a Block's signal_handler() method as a callback
+        This will register a Block's ``signal_handler()`` method as a callback
         for when signums[] is called. Note that since signals are associated
         with the main thread of i3pyblocks, each signal can only be assigned
         to a specific Block.
 
-        The received signal will be passed to Block.signal_handler() as a
+        The received signal will be passed to ``Block.signal_handler()`` as a
         parameter, so when receiving multiple signals it is possible to
         identify each of them separately.
 
-        This method capture the errors inside Block.signal_handler(), but
+        This method capture the errors inside ``Block.signal_handler()``, but
         it also logs it so you can inspect the issue later on.
 
-        Args:
-          block:
-            ``i3pyblocks.blocks.Block`` instance that will receive the signal.
-          signmums:
-            Any iterable containing signal numbers. Each signal can be an
-            int or a signal.Signals' enum.
+        :param block: ``i3pyblocks.blocks.Block`` instance that will receive
+            the signal.
+
+        :param signmums: Any iterable containing signal numbers. Each signal
+            can be an int or a signal.Signals' enum.
         """
 
         async def signal_handler(sig: signal.Signals):
             try:
                 logger.debug(
-                    f"Block {block.block_name} with id {block.id} received a signal {sig.name}"
+                    f"Block {block.block_name} with id {block.id} received "
+                    f"a signal {sig.name}"
                 )
                 await block.signal_handler(sig=sig)
             except Exception as e:
                 logger.exception(f"Exception in {block.block_name} signal handler")
                 block.abort(
-                    f"Exception in {block.block_name} signal handler: {e}", urgent=True
+                    f"Exception in {block.block_name} signal handler: {e}",
+                    urgent=True,
                 )
 
         def callback_fn(sig: signal.Signals):
@@ -91,10 +92,8 @@ class Runner:
     def register_task(self, awaitable: Awaitable) -> None:
         """Register a task that will be run in Runner's loop.
 
-        Args:
-          awaitable:
-            Either a coroutine, task or future that will be added to the task list
-            to be schedule inside main loop in i3pyblocks.
+        :param awaitable: Either a coroutine, task or future that will be added
+            to the task list to be schedule inside main loop in i3pyblocks.
         """
         task = asyncio.create_task(awaitable)
         self.tasks.append(task)
@@ -110,17 +109,15 @@ class Runner:
         This will register a new Block in Runner and also make sure that
         everything is ready to run the Block correctly.
 
-        Optionally it will also register any Unix signals that the Block
-        wants to wait for events (see ``Runner.register_signal()`` method).
+        Optionally it will also register any Unix signals that the Block wants
+        to wait for events (see ``Runner.register_signal()`` method).
 
-        Args:
-          block:
-            ``i3pyblocks.blocks.Block`` instance that will be registered
-            inside Runner's main loop.
-          signums:
-            Any iterable containing signal numbers, can be either an int or
-            a signal.Signals' enum. See ``Runner.register_signal()`` method
-            for more information.
+        :param block: ``i3pyblocks.blocks.Block`` instance that will be
+            registered inside Runner's main loop.
+
+        :param signums: Any iterable containing signal numbers, can be either
+            an int or a signal.Signals' enum. See ``Runner.register_signal()``
+            method for more information.
         """
         # Setup the block before starting it
         await block.setup(self.queue)
@@ -164,10 +161,8 @@ class Runner:
         the correspondent ``i3pyblocks.blocks.Block`` and calls its
         ``click_handler()`` method.
 
-        Args:
-          raw:
-            A JSON formatted string with the click event, as described in
-            https://i3wm.org/docs/i3bar-protocol.html#_click_events.
+        :param raw: A JSON formatted string with the click event, as described
+            in https://i3wm.org/docs/i3bar-protocol.html#_click_events.
         """
         try:
             click_event = json.loads(raw)
@@ -223,10 +218,8 @@ class Runner:
         the registered Blocks in the format expected by i3bar, and will also
         reads stdin for any click events coming from i3bar.
 
-        Args:
-          timeout:
-            Time in seconds to stop the Runner. This is mostly used by tests
-            or debug purposes.
+        :param timeout: Time in seconds to stop the Runner. This is mostly used
+            by tests or debug purposes.
         """
         self.register_task(self.click_events())
         self.register_task(self.write_results())

--- a/i3pyblocks/utils.py
+++ b/i3pyblocks/utils.py
@@ -2,40 +2,38 @@ from xml.etree import ElementTree as Tree
 
 
 def pango_markup(text: str, tag: str = "span", **attrib) -> str:
-    """Helper to generate Pango markup for text
+    r"""Helper to generate Pango markup for text.
 
     This helper makes it easier to generate Pango markup for arbitrary text,
     allowing for greater customization of text than the default attributes
     offered by i3bar protocol.
 
-    Args:
-      text:
-        Text to be put inside the tag.
-      tag:
-        XML tag that will be generated. By default it is ``<span>``.
-      **attrib:
-        Arbitrary attributes that will be added to tag.
+    Simple usage:
 
-    Examples:
-      Simple usage:
+    >>> pango_markup("Hello, world!", font_weight="bold")
+    '<span font_weight="bold">Hello, world!</span>'
 
-      >>> pango_markup("Hello, world!", font_weight="bold")
-      '<span font_weight="bold">Hello, world!</span>'
+    It can also generate markups for other tags supported in Pango:
 
-      It can also generate markups for other tags supported in Pango:
+    >>> pango_markup("Italic text", tag="i")
+    '<i>Italic text</i>'
 
-      >>> pango_markup("Italic text", tag="i")
-      '<i>Italic text</i>'
+    Keep in mind that there is no checks if your code is correct, so you can
+    pass completely nonsense attributes/tags that will be ignored by Pango:
 
-      Keep in mind that there is no checks if your code is correct, so you can
-      pass completely nonsense attributes/tags that will be ignored by Pango:
+    >>> pango_markup("Spam", foo="bar")
+    '<span foo="bar">Spam</span>'
 
-      >>> pango_markup("Spam", foo="bar")
-      '<span foo="bar">Spam</span>'
+    :param text: Text to be put inside the tag.
 
-    See Also:
-      Look at https://developer.gnome.org/pango/stable/pango-Markup.html for
-      information about the available tags and attributes.
+    :param tag: XML tag that will be generated. By default it is ``<span>``.
+
+    :param \*\*attrib: Arbitrary attributes that will be added to tag.
+
+    .. seealso::
+
+        Look at https://developer.gnome.org/pango/stable/pango-Markup.html for
+        information about the available tags and attributes.
     """
     e = Tree.Element(tag, attrib=attrib)
     e.text = text


### PR DESCRIPTION
The Google format is nicer to read, but you need to learn two grammars with it: Google and Sphinx (reST).

So instead let's just use Sphinx, so you just learn reST and it is all good.