### PR TITLE
Remove dependency injection

### DIFF
--- a/i3pyblocks/blocks/aiohttp.py
+++ b/i3pyblocks/blocks/aiohttp.py
@@ -90,8 +90,6 @@ class PollingRequestBlock(blocks.PollingBlock):
             [aiohttp.ClientResponse], Awaitable[str]
         ] = text_callback,
         sleep: int = 60,
-        *,
-        _aiohttp=aiohttp,
         **kwargs
     ) -> None:
         super().__init__(sleep=sleep, **kwargs)
@@ -101,11 +99,10 @@ class PollingRequestBlock(blocks.PollingBlock):
         self.method = method
         self.response_callback = response_callback
         self.request_opts = dict(request_opts)
-        self.aiohttp = _aiohttp
 
     async def run(self) -> None:
         try:
-            async with self.aiohttp.ClientSession() as session:
+            async with aiohttp.ClientSession() as session:
                 async with session.request(
                     method=self.method,
                     url=self.url,

--- a/i3pyblocks/blocks/aionotify.py
+++ b/i3pyblocks/blocks/aionotify.py
@@ -70,15 +70,12 @@ class FileWatcherBlock(blocks.Block):
         path: Union[Path, str, None],
         flags: Optional[aionotify.Flags] = None,
         format_file_not_found: str = "File not found {path}",
-        *,
-        _aionotify=aionotify,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.flags = flags
         self.path = Path(path) if path else None
         self.format_file_not_found = format_file_not_found
-        self.aionotify = _aionotify
 
     async def click_handler(
         self,
@@ -106,7 +103,7 @@ class FileWatcherBlock(blocks.Block):
             self.abort(full_text=self.format_file_not_found.format(path=self.path))
             return
 
-        watcher = self.aionotify.Watcher()
+        watcher = aionotify.Watcher()
         watcher.watch(str(self.path), flags=self.flags)
 
         try:
@@ -166,9 +163,6 @@ class BacklightBlock(FileWatcherBlock):
             (types.MouseButton.SCROLL_UP, None),
             (types.MouseButton.SCROLL_DOWN, None),
         ),
-        *,
-        _aionotify=aionotify,
-        _utils=utils,
         **kwargs,
     ) -> None:
         self.base_path = Path(base_path)
@@ -185,14 +179,11 @@ class BacklightBlock(FileWatcherBlock):
         if self.device_path:
             super().__init__(
                 path=self.device_path / "brightness",
-                flags=_aionotify.Flags.MODIFY,
-                _aionotify=_aionotify,
+                flags=aionotify.Flags.MODIFY,
                 **kwargs,
             )
         else:
             super().__init__(path=None, format_file_not_found=format_no_backlight)
-
-        self.utils = _utils
 
     async def click_handler(self, button: int, **_kwargs) -> None:
         command = self.command_on_click.get(button)
@@ -200,7 +191,7 @@ class BacklightBlock(FileWatcherBlock):
         if not command:
             return
 
-        await self.utils.shell_run(command)
+        await utils.shell_run(command)
 
     def _get_max_brightness(self) -> int:
         if self.device_path:

--- a/i3pyblocks/blocks/datetime.py
+++ b/i3pyblocks/blocks/datetime.py
@@ -36,15 +36,12 @@ class DateTimeBlock(blocks.PollingBlock):
         format_date: str = "%D",
         format_time: str = "%T",
         sleep: int = 1,
-        *,
-        _datetime=datetime,
-        **kwargs
+        **kwargs,
     ) -> None:
         super().__init__(sleep=sleep, **kwargs)
         self.format_date = format_date
         self.format_time = format_time
         self.format = self.format_time
-        self.datetime = _datetime
 
     async def click_handler(self, **_kwargs) -> None:
         if self.format == self.format_date:
@@ -55,5 +52,5 @@ class DateTimeBlock(blocks.PollingBlock):
         await self.run()
 
     async def run(self) -> None:
-        current_time = self.datetime.now()
+        current_time = datetime.now()
         self.update(current_time.strftime(self.format))

--- a/i3pyblocks/blocks/i3ipc.py
+++ b/i3pyblocks/blocks/i3ipc.py
@@ -10,8 +10,8 @@ only updating when it is actually needed.
     https://github.com/altdesktop/i3ipc-python
 """
 
-import i3ipc
-import i3ipc.aio
+from i3ipc import Event
+from i3ipc import aio as i3ipc_aio
 
 from i3pyblocks import blocks, core
 
@@ -28,15 +28,10 @@ class WindowTitleBlock(blocks.Block):
     def __init__(
         self,
         format: str = "{window_title:.81s}",
-        *,
-        _i3ipc=i3ipc,
-        _i3ipc_aio=i3ipc.aio,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.format = format
-        self.i3ipc = _i3ipc
-        self.i3ipc_aio = _i3ipc_aio
 
     async def clear_title(self, *_):
         self.update()
@@ -49,14 +44,14 @@ class WindowTitleBlock(blocks.Block):
 
     async def start(self) -> None:
         # https://git.io/Jft7j
-        connection = self.i3ipc_aio.Connection(auto_reconnect=True)
+        connection = i3ipc_aio.Connection(auto_reconnect=True)
 
         await connection.connect()
 
-        connection.on(self.i3ipc.Event.WORKSPACE_FOCUS, self.clear_title)
-        connection.on(self.i3ipc.Event.WINDOW_CLOSE, self.clear_title)
-        connection.on(self.i3ipc.Event.WINDOW_TITLE, self.update_title)
-        connection.on(self.i3ipc.Event.WINDOW_FOCUS, self.update_title)
+        connection.on(Event.WORKSPACE_FOCUS, self.clear_title)
+        connection.on(Event.WINDOW_CLOSE, self.clear_title)
+        connection.on(Event.WINDOW_TITLE, self.update_title)
+        connection.on(Event.WINDOW_FOCUS, self.update_title)
 
         try:
             await self.update_title(connection)

--- a/i3pyblocks/blocks/subprocess.py
+++ b/i3pyblocks/blocks/subprocess.py
@@ -48,8 +48,6 @@ class ShellBlock(blocks.PollingBlock):
         ),
         color_by_returncode: types.Dictable = (),
         sleep: int = 1,
-        *,
-        _utils=utils,
         **kwargs
     ) -> None:
         super().__init__(sleep=sleep, **kwargs)
@@ -57,7 +55,6 @@ class ShellBlock(blocks.PollingBlock):
         self.command = command
         self.command_on_click = dict(command_on_click)
         self.color_by_returncode = dict(color_by_returncode)
-        self.utils = _utils
 
     async def click_handler(self, button: int, **_kwargs) -> None:
         command = self.command_on_click.get(button)
@@ -65,7 +62,7 @@ class ShellBlock(blocks.PollingBlock):
         if not command:
             return
 
-        await self.utils.shell_run(command)
+        await utils.shell_run(command)
         await self.run()
 
     async def run(self) -> None:
@@ -117,8 +114,6 @@ class ToggleBlock(blocks.PollingBlock):
         format_on: str = "ON",
         format_off: str = "OFF",
         sleep: int = 1,
-        *,
-        _utils=utils,
         **kwargs
     ) -> None:
         super().__init__(sleep=sleep, **kwargs)
@@ -127,7 +122,6 @@ class ToggleBlock(blocks.PollingBlock):
         self.command_off = command_off
         self.format_on = format_on
         self.format_off = format_off
-        self.utils = _utils
 
     async def get_state(self) -> bool:
         stdout, _, _ = await utils.shell_run(self.command_state, stdout=subprocess.PIPE)
@@ -144,7 +138,7 @@ class ToggleBlock(blocks.PollingBlock):
         else:
             command = self.command_off
 
-        await self.utils.shell_run(command)
+        await utils.shell_run(command)
         await self.run()
 
     async def run(self) -> None:

--- a/i3pyblocks/blocks/xlib.py
+++ b/i3pyblocks/blocks/xlib.py
@@ -47,15 +47,12 @@ class DPMSBlock(blocks.PollingBlock):
         format_on: str = "DPMS ON",
         format_off: str = "DPMS OFF",
         sleep: int = 1,
-        *,
-        _Xdisplay=Xdisplay,
         **kwargs,
     ) -> None:
         super().__init__(sleep=sleep, **kwargs)
         self.format_on = format_on
         self.format_off = format_off
-        self.Xdisplay = _Xdisplay
-        self.display = self.Xdisplay.Display()
+        self.display = Xdisplay.Display()
         self.loop = asyncio.get_running_loop()
         self.executor = ThreadPoolExecutor(max_workers=1)
 

--- a/tests/blocks/test_datetime.py
+++ b/tests/blocks/test_datetime.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from unittest.mock import Mock
+from unittest.mock import patch
 
 import pytest
 
@@ -8,21 +8,20 @@ from i3pyblocks.blocks import datetime as m_datetime
 
 @pytest.mark.asyncio
 async def test_datetime_block():
-    mock_datetime = Mock(datetime)
-    mock_datetime.now.return_value = datetime(2020, 8, 25, 23, 30, 0)
+    mock_config = {"now.return_value": datetime(2020, 8, 25, 23, 30, 0)}
+    with patch("i3pyblocks.blocks.datetime.datetime", **mock_config):
+        # Use a non locale dependent format
+        instance = m_datetime.DateTimeBlock(
+            format_time="%H:%M:%S", format_date="%y-%m-%d"
+        )
+        await instance.run()
 
-    # Use a non locale dependent format
-    instance = m_datetime.DateTimeBlock(
-        format_time="%H:%M:%S", format_date="%y-%m-%d", _datetime=mock_datetime
-    )
-    await instance.run()
+        assert instance.result()["full_text"] == "23:30:00"
 
-    assert instance.result()["full_text"] == "23:30:00"
+        # Simulate click
+        await instance.click_handler()
+        assert instance.result()["full_text"] == "20-08-25"
 
-    # Simulate click
-    await instance.click_handler()
-    assert instance.result()["full_text"] == "20-08-25"
-
-    # Simulate another click, should go back to hours
-    await instance.click_handler()
-    assert instance.result()["full_text"] == "23:30:00"
+        # Simulate another click, should go back to hours
+        await instance.click_handler()
+        assert instance.result()["full_text"] == "23:30:00"

--- a/tests/blocks/test_i3ipc.py
+++ b/tests/blocks/test_i3ipc.py
@@ -1,40 +1,37 @@
 import pytest
-from asynctest import CoroutineMock, Mock
+from asynctest import CoroutineMock, patch
 from helpers import misc, task
 
-i3ipc = pytest.importorskip("i3ipc")
-i3ipc_aio = pytest.importorskip("i3ipc.aio")
 m_i3ipc = pytest.importorskip("i3pyblocks.blocks.i3ipc")
 
 
 @pytest.mark.asyncio
 async def test_window_title_block():
-    mock_i3ipc = Mock(i3ipc)
-    mock_i3ipc_aio = Mock(i3ipc_aio)
+    mock_config = {
+        "Connection.return_value.connect": CoroutineMock(),
+        "Connection.return_value.main": CoroutineMock(),
+        "Connection.return_value.get_tree": CoroutineMock(),
+    }
+    with patch("i3pyblocks.blocks.i3ipc.i3ipc_aio", **mock_config) as mock_i3ipc_aio:
+        mock_connection = mock_i3ipc_aio.Connection.return_value
 
-    mock_connection = mock_i3ipc_aio.Connection.return_value
-    # For some reason asynctest.Mock didn't work here
-    mock_connection.connect = CoroutineMock()
-    mock_connection.main = CoroutineMock()
-    mock_connection.get_tree = CoroutineMock()
+        tree_mock = mock_connection.get_tree.return_value
+        window_mock = tree_mock.find_focused
+        window_mock.return_value = misc.AttributeDict(name="Hello")
 
-    tree_mock = mock_connection.get_tree.return_value
-    window_mock = tree_mock.find_focused
-    window_mock.return_value = misc.AttributeDict(name="Hello")
+        instance = m_i3ipc.WindowTitleBlock()
+        await task.runner([instance.start()])
 
-    instance = m_i3ipc.WindowTitleBlock(_i3ipc=mock_i3ipc, _i3ipc_aio=mock_i3ipc_aio)
-    await task.runner([instance.start()])
+        result = instance.result()
+        assert result["full_text"] == "Hello"
 
-    result = instance.result()
-    assert result["full_text"] == "Hello"
+        await instance.clear_title()
 
-    await instance.clear_title()
+        result = instance.result()
+        assert result["full_text"] == ""
 
-    result = instance.result()
-    assert result["full_text"] == ""
-
-    # Sometimes window.name returns None
-    window_mock.return_value = misc.AttributeDict(name=None)
-    await instance.update_title(mock_connection)
-    result = instance.result()
-    assert result["full_text"] == ""
+        # Sometimes window.name returns None
+        window_mock.return_value = misc.AttributeDict(name=None)
+        await instance.update_title(mock_connection)
+        result = instance.result()
+        assert result["full_text"] == ""

--- a/tests/blocks/test_psutil.py
+++ b/tests/blocks/test_psutil.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import patch
 
 import pytest
 from helpers import misc
@@ -12,274 +12,289 @@ m_psutil = pytest.importorskip("i3pyblocks.blocks.psutil")
 
 @pytest.mark.asyncio
 async def test_cpu_percent_block():
-    mock_psutil = Mock(psutil)
-    mock_psutil.cpu_percent.return_value = 75.5
+    mock_config = {"cpu_percent.return_value": 75.5}
+    with patch("i3pyblocks.blocks.psutil.psutil", **mock_config):
+        instance = m_psutil.CpuPercentBlock(format="{icon} {percent}")
+        await instance.run()
 
-    instance = m_psutil.CpuPercentBlock(format="{icon} {percent}", _psutil=mock_psutil)
-    await instance.run()
+        result = instance.result()
 
-    result = instance.result()
-
-    assert result["full_text"] == "▇ 75.5"
-    assert result["color"] == types.Color.WARN
+        assert result["full_text"] == "▇ 75.5"
+        assert result["color"] == types.Color.WARN
 
 
 @pytest.mark.asyncio
 async def test_disk_usage_block():
-    mock_psutil = Mock(psutil)
-    mock_psutil.disk_usage.return_value = misc.AttributeDict(
-        total=226227036160, used=49354395648, free=165309575168, percent=91.3
-    )
+    mock_config = {
+        "disk_usage.return_value": misc.AttributeDict(
+            total=226227036160, used=49354395648, free=165309575168, percent=91.3
+        )
+    }
+    with patch("i3pyblocks.blocks.psutil.psutil", **mock_config):
+        instance = m_psutil.DiskUsageBlock(
+            format="{icon} {path} {total:.1f} {used:.1f} {free:.1f} {percent}",
+        )
+        await instance.run()
 
-    instance = m_psutil.DiskUsageBlock(
-        format="{icon} {path} {total:.1f} {used:.1f} {free:.1f} {percent}",
-        _psutil=mock_psutil,
-    )
-    await instance.run()
+        result = instance.result()
 
-    result = instance.result()
-
-    assert result["full_text"] == "█ / 210.7 46.0 154.0 91.3"
-    assert result["color"] == types.Color.URGENT
+        assert result["full_text"] == "█ / 210.7 46.0 154.0 91.3"
+        assert result["color"] == types.Color.URGENT
 
 
 @pytest.mark.asyncio
 async def test_disk_usage_block_with_short_path():
-    mock_psutil = Mock(psutil)
-    mock_psutil.disk_usage.return_value = misc.AttributeDict(
-        total=226227036160, used=49354395648, free=165309575168, percent=91.3
-    )
+    mock_config = {
+        "disk_usage.return_value": misc.AttributeDict(
+            total=226227036160, used=49354395648, free=165309575168, percent=91.3
+        )
+    }
     path_str = "/media/backup/Downloads"
 
-    instance = m_psutil.DiskUsageBlock(
-        path=Path(path_str),
-        format="{short_path}",
-        _psutil=mock_psutil,
-    )
-    await instance.run()
+    with patch("i3pyblocks.blocks.psutil.psutil", **mock_config) as mock_psutil:
+        instance = m_psutil.DiskUsageBlock(path=Path(path_str), format="{short_path}")
+        await instance.run()
 
-    # Making sure that we call psutil.disk_usage with str instead of Path
-    mock_psutil.disk_usage.assert_called_once_with(path_str)
+        # Making sure that we call psutil.disk_usage with str instead of Path
+        mock_psutil.disk_usage.assert_called_once_with(path_str)
 
-    result = instance.result()
+        result = instance.result()
 
-    assert result["full_text"] == "/m/b/D"
+        assert result["full_text"] == "/m/b/D"
 
 
 @pytest.mark.asyncio
 async def test_load_avg_block():
-    mock_psutil = Mock(psutil)
-    mock_psutil.getloadavg.return_value = (2.5, 5, 15)
+    mock_config = {"getloadavg.return_value": (2.5, 5, 15)}
+    with patch("i3pyblocks.blocks.psutil.psutil", **mock_config):
+        instance = m_psutil.LoadAvgBlock(
+            format="{load1} {load5} {load15}",
+            colors=(
+                (0, types.Color.NEUTRAL),
+                (2, types.Color.WARN),
+                (4, types.Color.URGENT),
+            ),
+        )
 
-    instance = m_psutil.LoadAvgBlock(
-        format="{load1} {load5} {load15}",
-        colors=(
-            (0, types.Color.NEUTRAL),
-            (2, types.Color.WARN),
-            (4, types.Color.URGENT),
-        ),
-        _psutil=mock_psutil,
-    )
+        await instance.run()
 
-    await instance.run()
+        result = instance.result()
 
-    result = instance.result()
-
-    assert result["full_text"] == "2.5 5 15"
-    assert result["color"] == types.Color.WARN
+        assert result["full_text"] == "2.5 5 15"
+        assert result["color"] == types.Color.WARN
 
 
 @pytest.mark.asyncio
 async def test_network_speed_block_down():
-    mock_psutil = Mock(psutil)
-    mock_psutil.net_if_stats.return_value = {
-        "lo": misc.AttributeDict(
-            isup=True, duplex=psutil.NIC_DUPLEX_UNKNOWN, speed=0, mtu=65536
-        ),
-        "eno1": misc.AttributeDict(
-            isup=False, duplex=psutil.NIC_DUPLEX_FULL, speed=1000, mtu=1500
-        ),
+    mock_config = {
+        "net_if_stats.return_value": {
+            "lo": misc.AttributeDict(
+                isup=True, duplex=psutil.NIC_DUPLEX_UNKNOWN, speed=0, mtu=65536
+            ),
+            "eno1": misc.AttributeDict(
+                isup=False, duplex=psutil.NIC_DUPLEX_FULL, speed=1000, mtu=1500
+            ),
+        }
     }
 
-    instance = m_psutil.NetworkSpeedBlock(
-        format_up="{interface} {upload} {download}", _psutil=mock_psutil
-    )
+    with patch("i3pyblocks.blocks.psutil.psutil", **mock_config):
+        instance = m_psutil.NetworkSpeedBlock(
+            format_up="{interface} {upload} {download}",
+        )
 
-    await instance.run()
+        await instance.run()
 
-    result = instance.result()
+        result = instance.result()
 
-    assert result["full_text"] == "NO NETWORK"
-    assert result["color"] == types.Color.URGENT
+        assert result["full_text"] == "NO NETWORK"
+        assert result["color"] == types.Color.URGENT
 
 
 @pytest.mark.asyncio
 async def test_network_speed_block_up():
-    mock_psutil = Mock(psutil)
-    mock_psutil.net_if_stats.return_value = {
-        "lo": misc.AttributeDict(
-            isup=True, duplex=psutil.NIC_DUPLEX_UNKNOWN, speed=0, mtu=65536
-        ),
-        "eno1": misc.AttributeDict(
-            isup=True, duplex=psutil.NIC_DUPLEX_FULL, speed=1000, mtu=1500
-        ),
+    mock_config = {
+        "net_if_stats.return_value": {
+            "lo": misc.AttributeDict(
+                isup=True, duplex=psutil.NIC_DUPLEX_UNKNOWN, speed=0, mtu=65536
+            ),
+            "eno1": misc.AttributeDict(
+                isup=True, duplex=psutil.NIC_DUPLEX_FULL, speed=1000, mtu=1500
+            ),
+        },
+        "net_io_counters.side_effect": [
+            {
+                "lo": misc.AttributeDict(
+                    bytes_sent=35052252,
+                    bytes_recv=35052252,
+                    packets_sent=72139,
+                    packets_recv=72139,
+                ),
+                "eno1": misc.AttributeDict(
+                    bytes_sent=1082551675,
+                    bytes_recv=2778549399,
+                    packets_sent=2198791,
+                    packets_recv=2589939,
+                ),
+            },
+            {
+                "lo": misc.AttributeDict(
+                    bytes_sent=35498316,
+                    bytes_recv=35498316,
+                    packets_sent=72619,
+                    packets_recv=72619,
+                ),
+                "eno1": misc.AttributeDict(
+                    bytes_sent=1093133039,
+                    bytes_recv=2789019792,
+                    packets_sent=2203911,
+                    packets_recv=2592307,
+                ),
+            },
+        ],
     }
 
-    mock_psutil.net_io_counters.side_effect = [
-        {
-            "lo": misc.AttributeDict(
-                bytes_sent=35052252,
-                bytes_recv=35052252,
-                packets_sent=72139,
-                packets_recv=72139,
-            ),
-            "eno1": misc.AttributeDict(
-                bytes_sent=1082551675,
-                bytes_recv=2778549399,
-                packets_sent=2198791,
-                packets_recv=2589939,
-            ),
-        },
-        {
-            "lo": misc.AttributeDict(
-                bytes_sent=35498316,
-                bytes_recv=35498316,
-                packets_sent=72619,
-                packets_recv=72619,
-            ),
-            "eno1": misc.AttributeDict(
-                bytes_sent=1093133039,
-                bytes_recv=2789019792,
-                packets_sent=2203911,
-                packets_recv=2592307,
-            ),
-        },
-    ]
+    with patch("i3pyblocks.blocks.psutil.psutil", **mock_config):
+        instance = m_psutil.NetworkSpeedBlock(
+            format_up="{interface} {upload} {download}"
+        )
 
-    instance = m_psutil.NetworkSpeedBlock(
-        format_up="{interface} {upload} {download}", _psutil=mock_psutil
-    )
+        await instance.run()
 
-    await instance.run()
+        result = instance.result()
 
-    result = instance.result()
-
-    assert result["full_text"] == "eno1 3.4M 3.3M"
-    assert result["color"] == types.Color.WARN
+        assert result["full_text"] == "eno1 3.4M 3.3M"
+        assert result["color"] == types.Color.WARN
 
 
 @pytest.mark.asyncio
 async def test_sensors_battery_block_without_battery():
-    mock_psutil = Mock(psutil)
-    mock_psutil.sensors_battery.return_value = None
+    mock_config = {"sensors_battery.return_value": None}
+    with patch("i3pyblocks.blocks.psutil.psutil", **mock_config):
+        instance = m_psutil.SensorsBatteryBlock()
 
-    instance = m_psutil.SensorsBatteryBlock(_psutil=mock_psutil)
+        await instance.run()
 
-    await instance.run()
+        result = instance.result()
 
-    result = instance.result()
-
-    assert result["full_text"] == "No battery"
+        assert result["full_text"] == "No battery"
 
 
 @pytest.mark.asyncio
 async def test_sensors_battery_block_with_battery():
-    mock_psutil = Mock(psutil)
-    mock_psutil.sensors_battery.side_effect = [
-        misc.AttributeDict(
-            percent=93, secsleft=psutil.POWER_TIME_UNLIMITED, power_plugged=True
-        ),
-        misc.AttributeDict(percent=23, secsleft=16628, power_plugged=False),
-        misc.AttributeDict(
-            percent=9, secsleft=psutil.POWER_TIME_UNKNOWN, power_plugged=False
-        ),
-    ]
+    mock_config = {
+        "sensors_battery.side_effect": [
+            misc.AttributeDict(
+                percent=93, secsleft=psutil.POWER_TIME_UNLIMITED, power_plugged=True
+            ),
+            misc.AttributeDict(percent=23, secsleft=16628, power_plugged=False),
+            misc.AttributeDict(
+                percent=9, secsleft=psutil.POWER_TIME_UNKNOWN, power_plugged=False
+            ),
+        ],
+        # Unmock those enums
+        "POWER_TIME_UNLIMITED": psutil.POWER_TIME_UNLIMITED,
+        "POWER_TIME_UNKNOWN": psutil.POWER_TIME_UNKNOWN,
+    }
 
-    instance = m_psutil.SensorsBatteryBlock(_psutil=mock_psutil)
+    with patch("i3pyblocks.blocks.psutil.psutil", **mock_config):
+        instance = m_psutil.SensorsBatteryBlock()
 
-    await instance.run()
+        await instance.run()
 
-    result = instance.result()
+        result = instance.result()
 
-    assert result["full_text"] == "B: PLUGGED 93%"
+        assert result["full_text"] == "B: PLUGGED 93%"
 
-    await instance.run()
+        await instance.run()
 
-    result = instance.result()
+        result = instance.result()
 
-    assert result["full_text"] == "B: ▂ 23% 4:37:08"
-    assert result["color"] == types.Color.WARN
+        assert result["full_text"] == "B: ▂ 23% 4:37:08"
+        assert result["color"] == types.Color.WARN
 
-    await instance.run()
+        await instance.run()
 
-    result = instance.result()
+        result = instance.result()
 
-    assert result["full_text"] == "B: ▁ 9%"
-    assert result["color"] == types.Color.URGENT
+        assert result["full_text"] == "B: ▁ 9%"
+        assert result["color"] == types.Color.URGENT
 
 
 @pytest.mark.asyncio
 async def test_sensors_temperature_block():
-    mock_psutil = Mock(psutil)
-    mock_psutil.sensors_temperatures.return_value = {
-        "coretemp": [
-            misc.AttributeDict(
-                label="Package id 0", current=78.0, high=82.0, critical=100.0
-            ),
-            misc.AttributeDict(label="Core 0", current=29.0, high=82.0, critical=100.0),
-            misc.AttributeDict(label="Core 1", current=28.0, high=82.0, critical=100.0),
-            misc.AttributeDict(label="Core 2", current=28.0, high=82.0, critical=100.0),
-            misc.AttributeDict(label="Core 3", current=28.0, high=82.0, critical=100.0),
-            misc.AttributeDict(label="Core 4", current=30.0, high=82.0, critical=100.0),
-            misc.AttributeDict(label="Core 5", current=28.0, high=82.0, critical=100.0),
-        ],
-        "acpitz": [
-            misc.AttributeDict(label="", current=16.8, high=18.8, critical=18.8),
-            misc.AttributeDict(label="", current=27.8, high=119.0, critical=119.0),
-            misc.AttributeDict(label="", current=29.8, high=119.0, critical=119.0),
-        ],
+    mock_config = {
+        "sensors_temperatures.return_value": {
+            "coretemp": [
+                misc.AttributeDict(
+                    label="Package id 0", current=78.0, high=82.0, critical=100.0
+                ),
+                misc.AttributeDict(
+                    label="Core 0", current=29.0, high=82.0, critical=100.0
+                ),
+                misc.AttributeDict(
+                    label="Core 1", current=28.0, high=82.0, critical=100.0
+                ),
+                misc.AttributeDict(
+                    label="Core 2", current=28.0, high=82.0, critical=100.0
+                ),
+                misc.AttributeDict(
+                    label="Core 3", current=28.0, high=82.0, critical=100.0
+                ),
+                misc.AttributeDict(
+                    label="Core 4", current=30.0, high=82.0, critical=100.0
+                ),
+                misc.AttributeDict(
+                    label="Core 5", current=28.0, high=82.0, critical=100.0
+                ),
+            ],
+            "acpitz": [
+                misc.AttributeDict(label="", current=16.8, high=18.8, critical=18.8),
+                misc.AttributeDict(label="", current=27.8, high=119.0, critical=119.0),
+                misc.AttributeDict(label="", current=29.8, high=119.0, critical=119.0),
+            ],
+        }
     }
 
-    instance_default = m_psutil.SensorsTemperaturesBlock(
-        format="{icon} {label} {current} {high} {critical}", _psutil=mock_psutil
-    )
+    with patch("i3pyblocks.blocks.psutil.psutil", **mock_config):
+        instance_default = m_psutil.SensorsTemperaturesBlock(
+            format="{icon} {label} {current} {high} {critical}"
+        )
 
-    await instance_default.run()
+        await instance_default.run()
 
-    result = instance_default.result()
+        result = instance_default.result()
 
-    assert result["full_text"] == "▇ Package id 0 78.0 82.0 100.0"
-    assert result["color"] == types.Color.WARN
+        assert result["full_text"] == "▇ Package id 0 78.0 82.0 100.0"
+        assert result["color"] == types.Color.WARN
 
-    instance_acpitz = m_psutil.SensorsTemperaturesBlock(
-        sensor="acpitz", _psutil=mock_psutil
-    )
+        instance_acpitz = m_psutil.SensorsTemperaturesBlock(sensor="acpitz")
 
-    await instance_acpitz.run()
+        await instance_acpitz.run()
 
-    result = instance_acpitz.result()
+        result = instance_acpitz.result()
 
-    assert result["full_text"] == "T: 17°C"
+        assert result["full_text"] == "T: 17°C"
 
 
 @pytest.mark.asyncio
 async def test_virtual_memory_block():
-    mock_psutil = Mock(psutil)
-    mock_psutil.virtual_memory.return_value = misc.AttributeDict(
-        total=16758484992,
-        available=13300297728,
-        percent=95.6,
-        used=2631917568,
-        free=10560126976,
-    )
+    mock_config = {
+        "virtual_memory.return_value": misc.AttributeDict(
+            total=16758484992,
+            available=13300297728,
+            percent=95.6,
+            used=2631917568,
+            free=10560126976,
+        )
+    }
 
-    instance = m_psutil.VirtualMemoryBlock(
-        format="{icon} {total:.1f} {available:.1f} {used:.1f} {free:.1f} {percent}",
-        _psutil=mock_psutil,
-    )
+    with patch("i3pyblocks.blocks.psutil.psutil", **mock_config):
+        instance = m_psutil.VirtualMemoryBlock(
+            format="{icon} {total:.1f} {available:.1f} {used:.1f} {free:.1f} {percent}",
+        )
 
-    await instance.run()
+        await instance.run()
 
-    result = instance.result()
+        result = instance.result()
 
-    assert result["full_text"] == "█ 15.6 12.4 2.5 9.8 95.6"
+        assert result["full_text"] == "█ 15.6 12.4 2.5 9.8 95.6"

--- a/tests/blocks/test_xlib.py
+++ b/tests/blocks/test_xlib.py
@@ -1,32 +1,37 @@
-from unittest.mock import Mock
-
 import pytest
+from asynctest import patch
 from helpers import misc
 
-Xdisplay = pytest.importorskip("Xlib.display")
 m_xlib = pytest.importorskip("i3pyblocks.blocks.xlib")
 
 
 @pytest.mark.asyncio
 async def test_dpms_block():
-    mock_Xdisplay = Mock(Xdisplay)
-    mock_Display = mock_Xdisplay.Display.return_value
-    mock_dpms_info = mock_Display.dpms_info
+    mock_config = {
+        "Display.return_value.dpms_info.side_effect": [
+            # One for run() call, another one for click_handler()
+            misc.AttributeDict(state=1),
+            misc.AttributeDict(state=1),
+            # One for run() call, another one for click_handler()
+            misc.AttributeDict(state=0),
+            misc.AttributeDict(state=0),
+        ]
+    }
+    with patch("i3pyblocks.blocks.xlib.Xdisplay", **mock_config) as mock_Xdisplay:
+        mock_Display = mock_Xdisplay.Display.return_value
 
-    instance = m_xlib.DPMSBlock(_Xdisplay=mock_Xdisplay)
+        instance = m_xlib.DPMSBlock()
 
-    mock_dpms_info.return_value = misc.AttributeDict(state=1)
-    await instance.run()
-    assert instance.result()["full_text"] == "DPMS ON"
+        await instance.run()
+        assert instance.result()["full_text"] == "DPMS ON"
 
-    await instance.click_handler()
-    mock_Display.dpms_disable.assert_called_once()
+        await instance.click_handler()
+        mock_Display.dpms_disable.assert_called_once()
 
-    mock_Display.reset_mock()
+        mock_Display.reset_mock()
 
-    mock_dpms_info.return_value = misc.AttributeDict(state=0)
-    await instance.run()
-    assert instance.result()["full_text"] == "DPMS OFF"
+        await instance.run()
+        assert instance.result()["full_text"] == "DPMS OFF"
 
-    await instance.click_handler()
-    mock_Display.dpms_enable.assert_called_once()
+        await instance.click_handler()
+        mock_Display.dpms_enable.assert_called_once()


### PR DESCRIPTION
While DI helped mocking some classes, there were also some disadvantages:

- The way I am using DI by injecting the class at constructor was showing at the documentation generated by Sphinx (and it was quite ugly).
- The usage was inconsistent between the project.

So let's go back to the mock approach. But there is a better way thanusing mocker, that is using `patch`. This brings almost all benefits of the DI, the only possible issue is when moving the class or renaming the imports. But this shouldn't happen too much.