### PR TITLE
Remove Dictable

### DIFF
--- a/example.py
+++ b/example.py
@@ -74,7 +74,12 @@ async def main():
     await runner.register_block(
         psutil.SensorsTemperaturesBlock(
             format="{icon} {current:.0f}°C",
-            icons=((0, ""), (25, ""), (50, ""), (75, "")),
+            icons={
+                0: "",
+                25: "",
+                50: "",
+                75: "",
+            },
         )
     )
 
@@ -89,7 +94,13 @@ async def main():
             format_plugged=" {percent:.0f}%",
             format_unplugged="{icon} {percent:.0f}% {remaining_time}",
             format_unknown="{icon} {percent:.0f}%",
-            icons=((0, ""), (10, ""), (25, ""), (50, ""), (75, "")),
+            icons={
+                0: "",
+                10: "",
+                25: "",
+                50: "",
+                75: "",
+            },
         )
     )
 
@@ -124,10 +135,10 @@ async def main():
         subprocess.ShellBlock(
             command="xkblayout-state print %s",
             format=" {output}",
-            command_on_click=(
-                (types.MouseButton.SCROLL_UP, "xkblayout-state set +1"),
-                (types.MouseButton.SCROLL_DOWN, "xkblayout-state set -1"),
-            ),
+            command_on_click={
+                types.MouseButton.SCROLL_UP: "xkblayout-state set +1",
+                types.MouseButton.SCROLL_DOWN: "xkblayout-state set -1",
+            },
         )
     )
 
@@ -139,10 +150,10 @@ async def main():
         aionotify.BacklightBlock(
             format=" {percent:.0f}%",
             format_no_backlight="",
-            command_on_click=(
-                (types.MouseButton.SCROLL_UP, "light -A 5%"),
-                (types.MouseButton.SCROLL_DOWN, "light -U 5"),
-            ),
+            command_on_click={
+                types.MouseButton.SCROLL_UP: "light -A 5%",
+                types.MouseButton.SCROLL_DOWN: "light -U 5",
+            },
         )
     )
 

--- a/i3pyblocks/_internal/models.py
+++ b/i3pyblocks/_internal/models.py
@@ -1,0 +1,38 @@
+import sys
+from typing import Mapping, Optional
+
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    try:
+        from typing_extensions import TypedDict
+    except ImportError:
+        from typing import Dict
+
+        class TypedDict(Dict):
+            """TypedDict shim for Python <3.8."""
+
+            def __init_subclass__(cls, **kwargs):
+                pass
+
+
+class State(TypedDict, total=False):
+    full_text: Optional[str]
+    short_text: Optional[str]
+    color: Optional[str]
+    background: Optional[str]
+    border: Optional[str]
+    border_top: Optional[int]
+    border_right: Optional[int]
+    border_bottom: Optional[int]
+    border_left: Optional[int]
+    min_width: Optional[int]
+    align: Optional[str]
+    urgent: Optional[bool]
+    separator: Optional[bool]
+    separator_block_width: Optional[int]
+    markup: Optional[str]
+
+
+Threshold = Mapping[float, Optional[str]]
+CommandToClick = Mapping[int, Optional[str]]

--- a/i3pyblocks/_internal/utils.py
+++ b/i3pyblocks/_internal/utils.py
@@ -1,18 +1,16 @@
 import asyncio
 import sys
 from asyncio import subprocess
-from typing import Dict, Optional, Tuple, Union
+from typing import Dict, Optional, Tuple
 
-from i3pyblocks import types
+from i3pyblocks._internal import models
 
 
-def calculate_threshold(
-    items: types.Dictable, value: Union[int, float]
-) -> Optional[str]:
+def calculate_threshold(items: models.Threshold, value: float) -> Optional[str]:
     selected_item = None
 
     for threshold, item in dict(items).items():
-        if value >= threshold:  # type: ignore
+        if value >= threshold:
             selected_item = item
         else:
             break

--- a/i3pyblocks/blocks/aiohttp.py
+++ b/i3pyblocks/blocks/aiohttp.py
@@ -21,11 +21,11 @@ IP).
 """
 
 import asyncio
-from typing import Any, Awaitable, Callable
+from typing import Any, Awaitable, Callable, Mapping
 
 import aiohttp
 
-from i3pyblocks import blocks, core, types
+from i3pyblocks import blocks, core
 
 DEFAULT_TIMEOUT = aiohttp.ClientTimeout(total=5)
 
@@ -55,8 +55,8 @@ class PollingRequestBlock(blocks.PollingBlock):
 
     :param format_error: Format string showed in case of an error in request.
 
-    :param request_opts: A Dictable of options passed directly to the
-        ``request()`` method in ``aiohttp``. The list of available parameters
+    :param request_opts: A mapping of options passed directly to the ``request()``
+        method in ``aiohttp``. The list of available parameters
         is `aiohttp docs`_.
 
     :param response_callback: A function that will be called after the response
@@ -85,7 +85,7 @@ class PollingRequestBlock(blocks.PollingBlock):
         method: str = "get",
         format: str = "{response}",
         format_error: str = "ERROR",
-        request_opts: types.Dictable[str, Any] = (("timeout", DEFAULT_TIMEOUT),),
+        request_opts: Mapping[str, Any] = {"timeout": DEFAULT_TIMEOUT},
         response_callback: Callable[
             [aiohttp.ClientResponse], Awaitable[str]
         ] = text_callback,
@@ -98,7 +98,7 @@ class PollingRequestBlock(blocks.PollingBlock):
         self.url = url
         self.method = method
         self.response_callback = response_callback
-        self.request_opts = dict(request_opts)
+        self.request_opts = request_opts
 
     async def run(self) -> None:
         try:

--- a/i3pyblocks/blocks/aionotify.py
+++ b/i3pyblocks/blocks/aionotify.py
@@ -25,7 +25,7 @@ from typing import List, Optional, Union
 import aionotify
 
 from i3pyblocks import blocks, core, types
-from i3pyblocks._internal import utils
+from i3pyblocks._internal import models, utils
 
 
 class FileWatcherBlock(blocks.Block):
@@ -137,7 +137,7 @@ class BacklightBlock(FileWatcherBlock):
         for some reason you want a specific device you can just use
         ``device_name`` here instead.
 
-    :param command_on_click: Dictable with commands to be called when the user
+    :param command_on_click: Mapping with commands to be called when the user
         interacts with mouse inside this block. Can be useful to adjust the
         backlight using scroll, for example.
 
@@ -156,13 +156,13 @@ class BacklightBlock(FileWatcherBlock):
         format_no_backlight: str = "No backlight",
         base_path: Union[Path, str] = "/sys/class/backlight/",
         device_glob: Optional[str] = "*",
-        command_on_click: types.Dictable = (
-            (types.MouseButton.LEFT_BUTTON, None),
-            (types.MouseButton.MIDDLE_BUTTON, None),
-            (types.MouseButton.RIGHT_BUTTON, None),
-            (types.MouseButton.SCROLL_UP, None),
-            (types.MouseButton.SCROLL_DOWN, None),
-        ),
+        command_on_click: models.CommandToClick = {
+            types.MouseButton.LEFT_BUTTON: None,
+            types.MouseButton.MIDDLE_BUTTON: None,
+            types.MouseButton.RIGHT_BUTTON: None,
+            types.MouseButton.SCROLL_UP: None,
+            types.MouseButton.SCROLL_DOWN: None,
+        },
         **kwargs,
     ) -> None:
         self.base_path = Path(base_path)
@@ -174,7 +174,7 @@ class BacklightBlock(FileWatcherBlock):
 
         self.format = format
         self.format_no_backlight = format_no_backlight
-        self.command_on_click = dict(command_on_click)
+        self.command_on_click = command_on_click
 
         if self.device_path:
             super().__init__(

--- a/i3pyblocks/blocks/base.py
+++ b/i3pyblocks/blocks/base.py
@@ -12,8 +12,8 @@ import uuid
 from concurrent.futures import Executor
 from typing import List, Optional
 
-from i3pyblocks import core, types
-from i3pyblocks._internal import utils
+from i3pyblocks import core
+from i3pyblocks._internal import models, utils
 
 
 class Block(metaclass=abc.ABCMeta):
@@ -59,21 +59,7 @@ class Block(metaclass=abc.ABCMeta):
         self,
         *,
         block_name: Optional[str] = None,
-        default_state: types.Dictable[str, Optional[types.Value]] = (
-            ("color", None),
-            ("background", None),
-            ("border", None),
-            ("border_top", None),
-            ("border_right", None),
-            ("border_bottom", None),
-            ("border_left", None),
-            ("min_width", None),
-            ("align", types.AlignText.LEFT),
-            ("urgent", False),
-            ("separator", True),
-            ("separator_block_width", None),
-            ("markup", types.MarkupText.NONE),
-        ),
+        default_state: models.State = {},
     ) -> None:
         self.id = uuid.uuid4()
         self.block_name = block_name or self.__class__.__name__
@@ -82,7 +68,7 @@ class Block(metaclass=abc.ABCMeta):
 
         # Those are default values for properties if they are not overriden
         self._default_state = utils.non_nullable_dict(
-            name=self.block_name, instance=str(self.id), **dict(default_state)
+            name=self.block_name, instance=str(self.id), **default_state
         )
 
         self.update_state()
@@ -187,21 +173,20 @@ class Block(metaclass=abc.ABCMeta):
             markup=markup,
         )
 
-    def result(self) -> types.Result:
-        """Returns the current state of Block as a Result map.
+    def result(self) -> models.State:
+        """Returns the current state of Block as a dict.
 
         This will combine both the default state and the current state to
         generate the current state of the Block.
 
-        :returns: A ``i3pyblocks.types.Result`` map, ready to be converted to
-            JSON. For example::
+        :returns: A State dict, ready to be converted to JSON. For example::
 
                 {
                     "full_text": "Some funny text",
                     "background": "#FF0000",
                 }
         """
-        return {**self._default_state, **self._state}
+        return {**self._default_state, **self._state}  # type: ignore
 
     def push_update(self) -> None:
         """Push result to queue, so it can be retrieved by Runner."""

--- a/i3pyblocks/blocks/psutil.py
+++ b/i3pyblocks/blocks/psutil.py
@@ -27,7 +27,7 @@ import psutil
 from psutil._common import bytes2human
 
 from i3pyblocks import blocks, types
-from i3pyblocks._internal import utils
+from i3pyblocks._internal import models, utils
 
 # Default CPU count to be used in LoadAvgBlock
 _CPU_COUNT = psutil.cpu_count()
@@ -39,7 +39,7 @@ class CpuPercentBlock(blocks.PollingBlock):
     :param format: Format string to shown. Supports both ``{percent}`` and
         ``{icon}`` placeholders.
 
-    :param colors: A Dictable that represents the color that will be shown in
+    :param colors: A mapping that represents the color that will be shown in
         each CPU interval. For example::
 
             {
@@ -63,28 +63,28 @@ class CpuPercentBlock(blocks.PollingBlock):
     def __init__(
         self,
         format: str = "C: {percent}%",
-        colors: types.Dictable[int, Optional[str]] = (
-            (0, types.Color.NEUTRAL),
-            (75, types.Color.WARN),
-            (90, types.Color.URGENT),
-        ),
-        icons: types.Dictable[float, str] = (
-            (0.0, "▁"),
-            (12.5, "▂"),
-            (25.0, "▃"),
-            (37.5, "▄"),
-            (50.0, "▅"),
-            (62.5, "▆"),
-            (75.0, "▇"),
-            (87.5, "█"),
-        ),
+        colors: models.Threshold = {
+            0: types.Color.NEUTRAL,
+            75: types.Color.WARN,
+            90: types.Color.URGENT,
+        },
+        icons: models.Threshold = {
+            0.0: "▁",
+            12.5: "▂",
+            25.0: "▃",
+            37.5: "▄",
+            50.0: "▅",
+            62.5: "▆",
+            75.0: "▇",
+            87.5: "█",
+        },
         sleep: int = 5,
         **kwargs,
     ) -> None:
         super().__init__(sleep=sleep, **kwargs)
         self.format = format
-        self.colors = dict(colors)
-        self.icons = dict(icons)
+        self.colors = colors
+        self.icons = icons
 
     async def run(self) -> None:
         percent = psutil.cpu_percent(interval=None)
@@ -117,7 +117,7 @@ class DiskUsageBlock(blocks.PollingBlock):
         - ``{percent}``: Disk usage in percentage
         - ``{icon}``: Show disk usage percentage in icon representation
 
-    :param colors: A Dictable that represents the color that will be shown in
+    :param colors: A mapping that represents the color that will be shown in
         each disk usage in percentage interval. For example::
 
             {
@@ -145,29 +145,29 @@ class DiskUsageBlock(blocks.PollingBlock):
         self,
         path: Union[Path, str] = "/",
         format: str = "{path}: {free:.1f}GiB",
-        colors: types.Dictable[int, Optional[str]] = (
-            (0, types.Color.NEUTRAL),
-            (75, types.Color.WARN),
-            (90, types.Color.URGENT),
-        ),
-        icons: types.Dictable[float, str] = (
-            (0.0, "▁"),
-            (12.5, "▂"),
-            (25.0, "▃"),
-            (37.5, "▄"),
-            (50.0, "▅"),
-            (62.5, "▆"),
-            (75.0, "▇"),
-            (87.5, "█"),
-        ),
+        colors: models.Threshold = {
+            0: types.Color.NEUTRAL,
+            75: types.Color.WARN,
+            90: types.Color.URGENT,
+        },
+        icons: models.Threshold = {
+            0.0: "▁",
+            12.5: "▂",
+            25.0: "▃",
+            37.5: "▄",
+            50.0: "▅",
+            62.5: "▆",
+            75.0: "▇",
+            87.5: "█",
+        },
         divisor: int = types.IECUnit.GiB,
         sleep: int = 5,
         **kwargs,
     ) -> None:
         super().__init__(sleep=sleep, **kwargs)
         self.format = format
-        self.colors = dict(colors)
-        self.icons = dict(icons)
+        self.colors = colors
+        self.icons = icons
         self.divisor = divisor
         self.path = Path(path)
         self.short_path = self._get_short_path()
@@ -204,8 +204,8 @@ class LoadAvgBlock(blocks.PollingBlock):
     :param format: Format string to shown. Supports the ``{load1}``, ``{load5}``
         and ``{load15}`` placeholders.
 
-    :param colors: A Dictable that represents the color that will be shown in
-        each load1 interval. For example::
+    :param colors: A mapping that represents the color that will be shown in each
+        load1 interval. For example::
 
             {
                 0: "000000",
@@ -229,17 +229,17 @@ class LoadAvgBlock(blocks.PollingBlock):
     def __init__(
         self,
         format: str = "L: {load1}",
-        colors: types.Dictable[int, Optional[str]] = (
-            (0, types.Color.NEUTRAL),
-            (_CPU_COUNT // 2, types.Color.WARN),
-            (_CPU_COUNT, types.Color.URGENT),
-        ),
+        colors: models.Threshold = {
+            0: types.Color.NEUTRAL,
+            _CPU_COUNT // 2: types.Color.WARN,
+            _CPU_COUNT: types.Color.URGENT,
+        },
         sleep: int = 5,
         **kwargs,
     ) -> None:
         super().__init__(sleep=sleep, **kwargs)
         self.format = format
-        self.colors = dict(colors)
+        self.colors = colors
 
     async def run(self) -> None:
         load1, load5, load15 = psutil.getloadavg()
@@ -268,7 +268,7 @@ class NetworkSpeedBlock(blocks.PollingBlock):
     :param format_down: Format string to shown when there is no connected
         interface.
 
-    :param colors: A Dictable that represents the color that will be shown in
+    :param colors: A mapping that represents the color that will be shown in
         each load1 interval. For example::
 
             {
@@ -294,11 +294,11 @@ class NetworkSpeedBlock(blocks.PollingBlock):
         self,
         format_up: str = "{interface}:  U {upload} D {download}",
         format_down: str = "NO NETWORK",
-        colors: types.Dictable[int, Optional[str]] = (
-            (0, types.Color.NEUTRAL),
-            (2 * types.IECUnit.MiB, types.Color.WARN),
-            (5 * types.IECUnit.MiB, types.Color.URGENT),
-        ),
+        colors: models.Threshold = {
+            0: types.Color.NEUTRAL,
+            2 * types.IECUnit.MiB: types.Color.WARN,
+            5 * types.IECUnit.MiB: types.Color.URGENT,
+        },
         interface_regex: str = "en*|eth*|ppp*|sl*|wl*|ww*",
         sleep: int = 3,
         **kwargs,
@@ -306,7 +306,7 @@ class NetworkSpeedBlock(blocks.PollingBlock):
         super().__init__(sleep=sleep, **kwargs)
         self.format_up = format_up
         self.format_down = format_down
-        self.colors = dict(colors)
+        self.colors = colors
         self.interface_regex = re.compile(interface_regex)
         self.previous = psutil.net_io_counters(pernic=True)
 
@@ -375,8 +375,8 @@ class SensorsBatteryBlock(blocks.PollingBlock):
 
     :param format_no_battery: Format string to shown when no battery is detected.
 
-    :param colors: A Dictable that represents the color that will be shown in
-        each battery percentage interval. For example::
+    :param colors: A mapping that represents the color that will be shown in each
+        battery percentage interval. For example::
 
             {
                 0: "000000",
@@ -403,21 +403,21 @@ class SensorsBatteryBlock(blocks.PollingBlock):
         format_unplugged: str = "B: {icon} {percent:.0f}% {remaining_time}",
         format_unknown: str = "B: {icon} {percent:.0f}%",
         format_no_battery: str = "No battery",
-        colors: types.Dictable[int, Optional[str]] = (
-            (0, types.Color.URGENT),
-            (10, types.Color.WARN),
-            (25, types.Color.NEUTRAL),
-        ),
-        icons: types.Dictable[float, str] = (
-            (0.0, "▁"),
-            (12.5, "▂"),
-            (25.0, "▃"),
-            (37.5, "▄"),
-            (50.0, "▅"),
-            (62.5, "▆"),
-            (75.0, "▇"),
-            (87.5, "█"),
-        ),
+        colors: models.Threshold = {
+            0: types.Color.URGENT,
+            10: types.Color.WARN,
+            25: types.Color.NEUTRAL,
+        },
+        icons: models.Threshold = {
+            0.0: "▁",
+            12.5: "▂",
+            25.0: "▃",
+            37.5: "▄",
+            50.0: "▅",
+            62.5: "▆",
+            75.0: "▇",
+            87.5: "█",
+        },
         sleep: int = 5,
         **kwargs,
     ):
@@ -426,8 +426,8 @@ class SensorsBatteryBlock(blocks.PollingBlock):
         self.format_unplugged = format_unplugged
         self.format_unknown = format_unknown
         self.format_no_battery = format_no_battery
-        self.colors = dict(colors)
-        self.icons = dict(icons)
+        self.colors = colors
+        self.icons = icons
 
     async def run(self):
         battery = psutil.sensors_battery()
@@ -468,7 +468,7 @@ class SensorsTemperaturesBlock(blocks.PollingBlock):
         - ``{critical}``: Critical temperature reported by sensor
         - ``{icon}``: Show sensor temperature in icon representation
 
-    :param colors: A Dictable that represents the color that will be shown in each
+    :param colors: A mapping that represents the color that will be shown in each
         temperature interval. For example::
 
             {
@@ -495,21 +495,21 @@ class SensorsTemperaturesBlock(blocks.PollingBlock):
     def __init__(
         self,
         format: str = "T: {current:.0f}°C",
-        colors: types.Dictable[int, Optional[str]] = (
-            (0, types.Color.NEUTRAL),
-            (60, types.Color.WARN),
-            (85, types.Color.URGENT),
-        ),
-        icons: types.Dictable[float, str] = (
-            (0.0, "▁"),
-            (12.5, "▂"),
-            (25.0, "▃"),
-            (37.5, "▄"),
-            (50.0, "▅"),
-            (62.5, "▆"),
-            (75.0, "▇"),
-            (87.5, "█"),
-        ),
+        colors: models.Threshold = {
+            0: types.Color.NEUTRAL,
+            60: types.Color.WARN,
+            85: types.Color.URGENT,
+        },
+        icons: models.Threshold = {
+            0.0: "▁",
+            12.5: "▂",
+            25.0: "▃",
+            37.5: "▄",
+            50.0: "▅",
+            62.5: "▆",
+            75.0: "▇",
+            87.5: "█",
+        },
         fahrenheit: bool = False,
         sensor: str = None,
         sleep: int = 5,
@@ -517,8 +517,8 @@ class SensorsTemperaturesBlock(blocks.PollingBlock):
     ) -> None:
         super().__init__(sleep=sleep, **kwargs)
         self.format = format
-        self.colors = dict(colors)
-        self.icons = dict(icons)
+        self.colors = colors
+        self.icons = icons
         self.fahrenheit = fahrenheit
         if sensor:
             self.sensor = sensor
@@ -556,8 +556,8 @@ class VirtualMemoryBlock(blocks.PollingBlock):
         - ``{percent}``: Percent used memory
         - ``{icon}``: Show memory percent in icon representation
 
-    :param colors: A Dictable that represents the color that will be shown in
-        each used memory percentage. For example::
+    :param colors: A mapping that represents the color that will be shown in each
+        used memory percentage. For example::
 
             {
                 0: "000000",
@@ -584,29 +584,29 @@ class VirtualMemoryBlock(blocks.PollingBlock):
     def __init__(
         self,
         format: str = "M: {available:.1f}GiB",
-        colors: types.Dictable[int, Optional[str]] = (
-            (0, types.Color.NEUTRAL),
-            (75, types.Color.WARN),
-            (90, types.Color.URGENT),
-        ),
-        icons: types.Dictable[float, str] = (
-            (0.0, "▁"),
-            (12.5, "▂"),
-            (25.0, "▃"),
-            (37.5, "▄"),
-            (50.0, "▅"),
-            (62.5, "▆"),
-            (75.0, "▇"),
-            (87.5, "█"),
-        ),
+        colors: models.Threshold = {
+            0: types.Color.NEUTRAL,
+            75: types.Color.WARN,
+            90: types.Color.URGENT,
+        },
+        icons: models.Threshold = {
+            0.0: "▁",
+            12.5: "▂",
+            25.0: "▃",
+            37.5: "▄",
+            50.0: "▅",
+            62.5: "▆",
+            75.0: "▇",
+            87.5: "█",
+        },
         divisor: int = types.IECUnit.GiB,
         sleep: int = 3,
         **kwargs,
     ) -> None:
         super().__init__(sleep=sleep, **kwargs)
         self.format = format
-        self.colors = dict(colors)
-        self.icons = dict(icons)
+        self.colors = colors
+        self.icons = icons
         self.divisor = divisor
 
     def _convert(self, dividend: float) -> float:

--- a/i3pyblocks/blocks/pulsectl.py
+++ b/i3pyblocks/blocks/pulsectl.py
@@ -25,7 +25,7 @@ from typing import NoReturn, Optional
 import pulsectl
 
 from i3pyblocks import blocks, types
-from i3pyblocks._internal import utils
+from i3pyblocks._internal import models, utils
 
 
 # Based on: https://git.io/fjbHp
@@ -44,8 +44,8 @@ class PulseAudioBlock(blocks.ExecutorBlock):
     :param format_mute: Format string showing when the audio sink is mute. It
         will be shown with ``color_mute`` set.
 
-    :param colors: A Dictable that represents the color that will be shown in
-        each volume interval. For example::
+    :param colors: A mapping that represents the color that will be shown in each
+        volume interval. For example::
 
             {
                 0: "000000",
@@ -74,31 +74,31 @@ class PulseAudioBlock(blocks.ExecutorBlock):
         self,
         format: str = "V: {volume:.0f}%",
         format_mute: str = "V: MUTE",
-        colors: types.Dictable[int, Optional[str]] = (
-            (0, types.Color.URGENT),
-            (10, types.Color.WARN),
-            (25, types.Color.NEUTRAL),
-        ),
+        colors: models.Threshold = {
+            0: types.Color.URGENT,
+            10: types.Color.WARN,
+            25: types.Color.NEUTRAL,
+        },
         color_mute: Optional[str] = types.Color.URGENT,
-        icons: types.Dictable[float, str] = (
-            (0.0, "▁"),
-            (12.5, "▂"),
-            (25.0, "▃"),
-            (37.5, "▄"),
-            (50.0, "▅"),
-            (62.5, "▆"),
-            (75.0, "▇"),
-            (87.5, "█"),
-        ),
+        icons: models.Threshold = {
+            0.0: "▁",
+            12.5: "▂",
+            25.0: "▃",
+            37.5: "▄",
+            50.0: "▅",
+            62.5: "▆",
+            75.0: "▇",
+            87.5: "█",
+        },
         command: str = "pavucontrol",
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.format = format
         self.format_mute = format_mute
-        self.colors = dict(colors)
+        self.colors = colors
         self.color_mute = color_mute
-        self.icons = dict(icons)
+        self.icons = icons
         self.command = command
 
         # https://pypi.org/project/pulsectl/#event-handling-code-threads

--- a/i3pyblocks/core.py
+++ b/i3pyblocks/core.py
@@ -16,8 +16,8 @@ import signal
 import uuid
 from typing import AnyStr, Awaitable, Dict, Iterable, List, Optional, Union
 
-from i3pyblocks import blocks, types
-from i3pyblocks._internal import utils
+from i3pyblocks import blocks
+from i3pyblocks._internal import models, utils
 
 logger = logging.getLogger("i3pyblocks")
 logger.addHandler(logging.NullHandler())
@@ -37,7 +37,7 @@ class Runner:
     def __init__(self) -> None:
         self.loop = asyncio.get_event_loop()
         self.blocks: Dict[uuid.UUID, blocks.Block] = {}
-        self.results: Dict[uuid.UUID, Optional[types.Result]] = {}
+        self.results: Dict[uuid.UUID, Optional[models.State]] = {}
         self.tasks: List[asyncio.Future] = []
         self.queue: asyncio.Queue = asyncio.Queue()
 

--- a/i3pyblocks/types.py
+++ b/i3pyblocks/types.py
@@ -1,13 +1,4 @@
-from typing import Dict, Iterable, Optional, Tuple, TypeVar, Union
-
-Value = Union[bool, int, str]
-Result = Dict[str, Value]
-
-KT = TypeVar("KT")
-VT = TypeVar("VT")
-
-# Dictable is either a Dict or something that can be converted to one
-Dictable = Union[Dict[KT, VT], Iterable[Tuple[KT, VT]]]
+from typing import Optional
 
 
 class AlignText:

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ pyparsing==2.4.7          # via packaging
 pytest-aiohttp==0.3.0     # via -r requirements/dev.in
 pytest-asyncio==0.14.0    # via -r requirements/dev.in
 pytest-cov==2.10.1        # via -r requirements/dev.in
-pytest==6.0.1             # via -r requirements/dev.in, pytest-aiohttp, pytest-asyncio, pytest-cov
+pytest==6.0.2             # via -r requirements/dev.in, pytest-aiohttp, pytest-asyncio, pytest-cov
 git+https://github.com/thiagokokada/python-xlib@152a2510d6710ce1fa4b4c341750ee1c6d449987#python-xlib  # via -r requirements/meta.in, i3ipc
 regex==2020.7.14          # via black
 six==1.15.0               # via packaging, pip-tools, python-xlib

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 max-line-length = 88
 select = C,E,F,W,B,B950
-ignore = E501,W503,E203
+ignore = E501,W503,E203,B006
 per-file-ignores =
     */__init__.py: F401, F403
 

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,9 @@ setuptools.setup(
     url="https://github.com/thiagokokada/i3pyblocks",
     packages=setuptools.find_packages(),
     entry_points={"console_scripts": ["i3pyblocks = i3pyblocks.cli:main"]},
+    install_requires=[
+        "typing_extensions>=3.7.4; python_version < '3.8'",
+    ],
     extras_require={
         "aiohttp": ["aiohttp>=3.4.0"],
         "aionotify": ["aionotify>=0.2.0"],

--- a/tests/blocks/test_aionotify.py
+++ b/tests/blocks/test_aionotify.py
@@ -168,13 +168,13 @@ async def test_backlight_block_click_handler(tmpdir):
     with patch("i3pyblocks.blocks.aionotify.utils", **mock_config) as mock_utils:
         instance = m_aionotify.BacklightBlock(
             base_path=tmpdir,
-            command_on_click=(
-                (types.MouseButton.LEFT_BUTTON, "LEFT_BUTTON"),
-                (types.MouseButton.MIDDLE_BUTTON, "MIDDLE_BUTTON"),
-                (types.MouseButton.RIGHT_BUTTON, "RIGHT_BUTTON"),
-                (types.MouseButton.SCROLL_UP, "SCROLL_UP"),
-                (types.MouseButton.SCROLL_DOWN, "SCROLL_DOWN"),
-            ),
+            command_on_click={
+                types.MouseButton.LEFT_BUTTON: "LEFT_BUTTON",
+                types.MouseButton.MIDDLE_BUTTON: "MIDDLE_BUTTON",
+                types.MouseButton.RIGHT_BUTTON: "RIGHT_BUTTON",
+                types.MouseButton.SCROLL_UP: "SCROLL_UP",
+                types.MouseButton.SCROLL_DOWN: "SCROLL_DOWN",
+            },
         )
 
         for button in [

--- a/tests/blocks/test_subprocess.py
+++ b/tests/blocks/test_subprocess.py
@@ -19,7 +19,7 @@ async def test_shell_block():
         exit 1
         """,
         format="{output} {output_err}",
-        color_by_returncode=((1, types.Color.URGENT),),
+        color_by_returncode={1: types.Color.URGENT},
     )
     await instance.run()
 
@@ -43,13 +43,13 @@ async def test_shell_block_click_handler():
     with patch("i3pyblocks.blocks.subprocess.utils", **mock_config) as mock_utils:
         instance = m_sub.ShellBlock(
             command="exit 0",
-            command_on_click=(
-                (types.MouseButton.LEFT_BUTTON, "LEFT_BUTTON"),
-                (types.MouseButton.MIDDLE_BUTTON, "MIDDLE_BUTTON"),
-                (types.MouseButton.RIGHT_BUTTON, "RIGHT_BUTTON"),
-                (types.MouseButton.SCROLL_UP, "SCROLL_UP"),
-                (types.MouseButton.SCROLL_DOWN, "SCROLL_DOWN"),
-            ),
+            command_on_click={
+                types.MouseButton.LEFT_BUTTON: "LEFT_BUTTON",
+                types.MouseButton.MIDDLE_BUTTON: "MIDDLE_BUTTON",
+                types.MouseButton.RIGHT_BUTTON: "RIGHT_BUTTON",
+                types.MouseButton.SCROLL_UP: "SCROLL_UP",
+                types.MouseButton.SCROLL_DOWN: "SCROLL_DOWN",
+            },
         )
 
         for button in [


### PR DESCRIPTION
Uses `TypedDict` from Python 3.8 instead, or `typing_extensions` in Python 3.7 (it even tries to works in Python 3.7 without `typing_extensions` via shim).