### PR TITLE
Add stable release of python-xlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,7 @@ pytest-aiohttp==0.3.0     # via i3pyblocks
 pytest-asyncio==0.14.0    # via i3pyblocks
 pytest-cov==2.10.1        # via i3pyblocks
 pytest==6.0.2             # via i3pyblocks, pytest-aiohttp, pytest-asyncio, pytest-cov
-git+https://github.com/python-xlib/python-xlib@128c60c681a40a843f2935efcc30d80614a065bf#python-xlib  # via -r requirements/meta.in, i3ipc
+python-xlib==0.28         # via i3ipc, i3pyblocks
 pytz==2020.1              # via babel
 pyyaml==5.3.1             # via sphinx-autoapi
 regex==2020.7.14          # via black

--- a/requirements/meta.in
+++ b/requirements/meta.in
@@ -8,9 +8,8 @@ blocks.i3ipc,\
 blocks.inotify,\
 blocks.ps,\
 blocks.pulse,\
+blocks.x11,\
 dev,\
 docs,\
 test\
 ]
-# Pinning manually a version here until python-xlib 0.28 is released
-git+https://github.com/python-xlib/python-xlib@128c60c681a40a843f2935efcc30d80614a065bf#python-xlib

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,7 @@ setuptools.setup(
         "blocks.inotify": ["aionotify>=0.2.0"],
         "blocks.ps": ["psutil>=5.4.8"],
         "blocks.pulse": ["pulsectl>=18.10.5"],
-        # Future version not released yet
-        "blocks.x11": ["python-xlib>0.2.7"],
+        "blocks.x11": ["python-xlib>=0.2.8"],
         # Non-runtime deps
         "dev": [
             "black",


### PR DESCRIPTION
`python-xlib` 0.28 has released. https://github.com/python-xlib/python-xlib/releases/tag/0.28