### PR TITLE
Add stricter mocks

### DIFF
--- a/tests/blocks/test_datetime.py
+++ b/tests/blocks/test_datetime.py
@@ -8,8 +8,13 @@ from i3pyblocks.blocks import datetime as m_datetime
 
 @pytest.mark.asyncio
 async def test_datetime_block():
-    mock_config = {"now.return_value": datetime(2020, 8, 25, 23, 30, 0)}
-    with patch("i3pyblocks.blocks.datetime.datetime", **mock_config):
+    with patch(
+        "i3pyblocks.blocks.datetime.datetime", autospec=True, spec_set=True
+    ) as mock_datetime:
+        mock_datetime.configure_mock(
+            **{"now.return_value": datetime(2020, 8, 25, 23, 30, 0)}
+        )
+
         # Use a non locale dependent format
         instance = m_datetime.DateTimeBlock(
             format_time="%H:%M:%S", format_date="%y-%m-%d"

--- a/tests/blocks/test_dbus.py
+++ b/tests/blocks/test_dbus.py
@@ -11,11 +11,15 @@ async def test_dbus_block():
         async def start(self):
             pass
 
-    mock_config = {
-        "MessageBus.return_value.connect": CoroutineMock(),
-        "MessageBus.return_value.connect.return_value.introspect": CoroutineMock(),
-    }
-    with patch("i3pyblocks.blocks.dbus.dbus_aio", **mock_config) as mock_dbus_aio:
+    with patch(
+        "i3pyblocks.blocks.dbus.dbus_aio", autospec=True, spec_set=True
+    ) as mock_dbus_aio:
+        mock_dbus_aio.configure_mock(
+            **{
+                "MessageBus.return_value.connect": CoroutineMock(),
+                "MessageBus.return_value.connect.return_value.introspect": CoroutineMock(),
+            }
+        )
         instance = ValidDbusBlock()
         await instance.setup()
 
@@ -38,11 +42,15 @@ async def test_dbus_block():
 
 @pytest.mark.asyncio
 async def test_kbdd_block():
-    mock_config = {
-        "MessageBus.return_value.connect": CoroutineMock(),
-        "MessageBus.return_value.connect.return_value.introspect": CoroutineMock(),
-    }
-    with patch("i3pyblocks.blocks.dbus.dbus_aio", **mock_config) as mock_dbus_aio:
+    with patch(
+        "i3pyblocks.blocks.dbus.dbus_aio", autospec=True, spec_set=True
+    ) as mock_dbus_aio:
+        mock_dbus_aio.configure_mock(
+            **{
+                "MessageBus.return_value.connect": CoroutineMock(),
+                "MessageBus.return_value.connect.return_value.introspect": CoroutineMock(),
+            }
+        )
         instance = dbus.KbddBlock(format="{full_layout:.2s}")
         await instance.setup()
 

--- a/tests/blocks/test_i3ipc.py
+++ b/tests/blocks/test_i3ipc.py
@@ -2,24 +2,28 @@ import pytest
 from asynctest import CoroutineMock, patch
 from helpers import misc, task
 
-m_i3ipc = pytest.importorskip("i3pyblocks.blocks.i3ipc")
+i3ipc = pytest.importorskip("i3pyblocks.blocks.i3ipc")
 
 
 @pytest.mark.asyncio
 async def test_window_title_block():
-    mock_config = {
-        "Connection.return_value.connect": CoroutineMock(),
-        "Connection.return_value.main": CoroutineMock(),
-        "Connection.return_value.get_tree": CoroutineMock(),
-    }
-    with patch("i3pyblocks.blocks.i3ipc.i3ipc_aio", **mock_config) as mock_i3ipc_aio:
+    with patch(
+        "i3pyblocks.blocks.i3ipc.i3ipc_aio", autospec=True, spec_set=True
+    ) as mock_i3ipc_aio:
+        mock_i3ipc_aio.configure_mock(
+            **{
+                "Connection.return_value.connect": CoroutineMock(),
+                "Connection.return_value.main": CoroutineMock(),
+                "Connection.return_value.get_tree": CoroutineMock(),
+            }
+        )
         mock_connection = mock_i3ipc_aio.Connection.return_value
 
         tree_mock = mock_connection.get_tree.return_value
         window_mock = tree_mock.find_focused
         window_mock.return_value = misc.AttributeDict(name="Hello")
 
-        instance = m_i3ipc.WindowTitleBlock()
+        instance = i3ipc.WindowTitleBlock()
         await task.runner([instance.start()])
 
         result = instance.result()

--- a/tests/blocks/test_inotify.py
+++ b/tests/blocks/test_inotify.py
@@ -157,13 +157,17 @@ async def test_backlight_block_without_backlight(tmpdir):
 
 @pytest.mark.asyncio
 async def test_backlight_block_click_handler(tmpdir):
-    mock_config = {
-        "arun": CoroutineMock(),
-        "arun.return_value": (misc.AttributeDict(returncode=0)),
-    }
     with patch(
-        "i3pyblocks.blocks.inotify.subprocess", **mock_config
+        "i3pyblocks.blocks.inotify.subprocess",
+        autospec=True,
+        spec_set=True,
     ) as mock_subprocess:
+        mock_subprocess.configure_mock(
+            **{
+                "arun": CoroutineMock(),
+                "arun.return_value": (misc.AttributeDict(returncode=0)),
+            }
+        )
         instance = inotify.BacklightBlock(
             base_path=tmpdir,
             command_on_click={

--- a/tests/blocks/test_ps.py
+++ b/tests/blocks/test_ps.py
@@ -9,11 +9,18 @@ from i3pyblocks import types
 psutil = pytest.importorskip("psutil")
 ps = pytest.importorskip("i3pyblocks.blocks.ps")
 
+PSUTIL_MOCK_CONFIG = {
+    "target": "i3pyblocks.blocks.ps.psutil",
+    "autospec": True,
+    "spec_set": True,
+}
+
 
 @pytest.mark.asyncio
 async def test_cpu_percent_block():
-    mock_config = {"cpu_percent.return_value": 75.5}
-    with patch("i3pyblocks.blocks.ps.psutil", **mock_config):
+    with patch(**PSUTIL_MOCK_CONFIG) as mock_psutil:
+        mock_psutil.configure_mock(**{"cpu_percent.return_value": 75.5})
+
         instance = ps.CpuPercentBlock(format="{icon} {percent}")
         await instance.run()
 
@@ -25,12 +32,18 @@ async def test_cpu_percent_block():
 
 @pytest.mark.asyncio
 async def test_disk_usage_block():
-    mock_config = {
-        "disk_usage.return_value": misc.AttributeDict(
-            total=226227036160, used=49354395648, free=165309575168, percent=91.3
+    with patch(**PSUTIL_MOCK_CONFIG) as mock_psutil:
+        mock_psutil.configure_mock(
+            **{
+                "disk_usage.return_value": misc.AttributeDict(
+                    total=226227036160,
+                    used=49354395648,
+                    free=165309575168,
+                    percent=91.3,
+                )
+            }
         )
-    }
-    with patch("i3pyblocks.blocks.ps.psutil", **mock_config):
+
         instance = ps.DiskUsageBlock(
             format="{icon} {path} {total:.1f} {used:.1f} {free:.1f} {percent}",
         )
@@ -44,14 +57,19 @@ async def test_disk_usage_block():
 
 @pytest.mark.asyncio
 async def test_disk_usage_block_with_short_path():
-    mock_config = {
-        "disk_usage.return_value": misc.AttributeDict(
-            total=226227036160, used=49354395648, free=165309575168, percent=91.3
-        )
-    }
     path_str = "/media/backup/Downloads"
 
-    with patch("i3pyblocks.blocks.ps.psutil", **mock_config) as mock_psutil:
+    with patch(**PSUTIL_MOCK_CONFIG) as mock_psutil:
+        mock_psutil.configure_mock(
+            **{
+                "disk_usage.return_value": misc.AttributeDict(
+                    total=226227036160,
+                    used=49354395648,
+                    free=165309575168,
+                    percent=91.3,
+                )
+            }
+        )
         instance = ps.DiskUsageBlock(path=Path(path_str), format="{short_path}")
         await instance.run()
 
@@ -65,8 +83,8 @@ async def test_disk_usage_block_with_short_path():
 
 @pytest.mark.asyncio
 async def test_load_avg_block():
-    mock_config = {"getloadavg.return_value": (2.5, 5, 15)}
-    with patch("i3pyblocks.blocks.ps.psutil", **mock_config):
+    with patch(**PSUTIL_MOCK_CONFIG) as mock_psutil:
+        mock_psutil.configure_mock(**{"getloadavg.return_value": (2.5, 5, 15)})
         instance = ps.LoadAvgBlock(
             format="{load1} {load5} {load15}",
             colors=(
@@ -86,18 +104,19 @@ async def test_load_avg_block():
 
 @pytest.mark.asyncio
 async def test_network_speed_block_down():
-    mock_config = {
-        "net_if_stats.return_value": {
-            "lo": misc.AttributeDict(
-                isup=True, duplex=psutil.NIC_DUPLEX_UNKNOWN, speed=0, mtu=65536
-            ),
-            "eno1": misc.AttributeDict(
-                isup=False, duplex=psutil.NIC_DUPLEX_FULL, speed=1000, mtu=1500
-            ),
-        }
-    }
-
-    with patch("i3pyblocks.blocks.ps.psutil", **mock_config):
+    with patch(**PSUTIL_MOCK_CONFIG) as mock_psutil:
+        mock_psutil.configure_mock(
+            **{
+                "net_if_stats.return_value": {
+                    "lo": misc.AttributeDict(
+                        isup=True, duplex=psutil.NIC_DUPLEX_UNKNOWN, speed=0, mtu=65536
+                    ),
+                    "eno1": misc.AttributeDict(
+                        isup=False, duplex=psutil.NIC_DUPLEX_FULL, speed=1000, mtu=1500
+                    ),
+                }
+            }
+        )
         instance = ps.NetworkSpeedBlock(
             format_up="{interface} {upload} {download}",
         )
@@ -112,48 +131,49 @@ async def test_network_speed_block_down():
 
 @pytest.mark.asyncio
 async def test_network_speed_block_up():
-    mock_config = {
-        "net_if_stats.return_value": {
-            "lo": misc.AttributeDict(
-                isup=True, duplex=psutil.NIC_DUPLEX_UNKNOWN, speed=0, mtu=65536
-            ),
-            "eno1": misc.AttributeDict(
-                isup=True, duplex=psutil.NIC_DUPLEX_FULL, speed=1000, mtu=1500
-            ),
-        },
-        "net_io_counters.side_effect": [
-            {
-                "lo": misc.AttributeDict(
-                    bytes_sent=35052252,
-                    bytes_recv=35052252,
-                    packets_sent=72139,
-                    packets_recv=72139,
-                ),
-                "eno1": misc.AttributeDict(
-                    bytes_sent=1082551675,
-                    bytes_recv=2778549399,
-                    packets_sent=2198791,
-                    packets_recv=2589939,
-                ),
-            },
-            {
-                "lo": misc.AttributeDict(
-                    bytes_sent=35498316,
-                    bytes_recv=35498316,
-                    packets_sent=72619,
-                    packets_recv=72619,
-                ),
-                "eno1": misc.AttributeDict(
-                    bytes_sent=1093133039,
-                    bytes_recv=2789019792,
-                    packets_sent=2203911,
-                    packets_recv=2592307,
-                ),
-            },
-        ],
-    }
-
-    with patch("i3pyblocks.blocks.ps.psutil", **mock_config):
+    with patch(**PSUTIL_MOCK_CONFIG) as mock_psutil:
+        mock_psutil.configure_mock(
+            **{
+                "net_if_stats.return_value": {
+                    "lo": misc.AttributeDict(
+                        isup=True, duplex=psutil.NIC_DUPLEX_UNKNOWN, speed=0, mtu=65536
+                    ),
+                    "eno1": misc.AttributeDict(
+                        isup=True, duplex=psutil.NIC_DUPLEX_FULL, speed=1000, mtu=1500
+                    ),
+                },
+                "net_io_counters.side_effect": [
+                    {
+                        "lo": misc.AttributeDict(
+                            bytes_sent=35052252,
+                            bytes_recv=35052252,
+                            packets_sent=72139,
+                            packets_recv=72139,
+                        ),
+                        "eno1": misc.AttributeDict(
+                            bytes_sent=1082551675,
+                            bytes_recv=2778549399,
+                            packets_sent=2198791,
+                            packets_recv=2589939,
+                        ),
+                    },
+                    {
+                        "lo": misc.AttributeDict(
+                            bytes_sent=35498316,
+                            bytes_recv=35498316,
+                            packets_sent=72619,
+                            packets_recv=72619,
+                        ),
+                        "eno1": misc.AttributeDict(
+                            bytes_sent=1093133039,
+                            bytes_recv=2789019792,
+                            packets_sent=2203911,
+                            packets_recv=2592307,
+                        ),
+                    },
+                ],
+            }
+        )
         instance = ps.NetworkSpeedBlock(format_up="{interface} {upload} {download}")
 
         await instance.run()
@@ -166,23 +186,28 @@ async def test_network_speed_block_up():
 
 @pytest.mark.asyncio
 async def test_sensors_battery_block():
-    mock_config = {
-        "sensors_battery.side_effect": [
-            misc.AttributeDict(
-                percent=93, secsleft=psutil.POWER_TIME_UNLIMITED, power_plugged=True
-            ),
-            misc.AttributeDict(percent=23, secsleft=16628, power_plugged=False),
-            None,
-            misc.AttributeDict(
-                percent=9, secsleft=psutil.POWER_TIME_UNKNOWN, power_plugged=False
-            ),
-        ],
-        # Unmock those enums
-        "POWER_TIME_UNLIMITED": psutil.POWER_TIME_UNLIMITED,
-        "POWER_TIME_UNKNOWN": psutil.POWER_TIME_UNKNOWN,
-    }
-
-    with patch("i3pyblocks.blocks.ps.psutil", **mock_config):
+    with patch(**PSUTIL_MOCK_CONFIG) as mock_psutil:
+        mock_psutil.configure_mock(
+            **{
+                "sensors_battery.side_effect": [
+                    misc.AttributeDict(
+                        percent=93,
+                        secsleft=psutil.POWER_TIME_UNLIMITED,
+                        power_plugged=True,
+                    ),
+                    misc.AttributeDict(percent=23, secsleft=16628, power_plugged=False),
+                    None,
+                    misc.AttributeDict(
+                        percent=9,
+                        secsleft=psutil.POWER_TIME_UNKNOWN,
+                        power_plugged=False,
+                    ),
+                ],
+                # Unmock those enums
+                "POWER_TIME_UNLIMITED": psutil.POWER_TIME_UNLIMITED,
+                "POWER_TIME_UNKNOWN": psutil.POWER_TIME_UNKNOWN,
+            }
+        )
         instance = ps.SensorsBatteryBlock()
 
         await instance.run()
@@ -208,40 +233,50 @@ async def test_sensors_battery_block():
 
 @pytest.mark.asyncio
 async def test_sensors_temperature_block():
-    mock_config = {
-        "sensors_temperatures.return_value": {
-            "coretemp": [
-                misc.AttributeDict(
-                    label="Package id 0", current=78.0, high=82.0, critical=100.0
-                ),
-                misc.AttributeDict(
-                    label="Core 0", current=29.0, high=82.0, critical=100.0
-                ),
-                misc.AttributeDict(
-                    label="Core 1", current=28.0, high=82.0, critical=100.0
-                ),
-                misc.AttributeDict(
-                    label="Core 2", current=28.0, high=82.0, critical=100.0
-                ),
-                misc.AttributeDict(
-                    label="Core 3", current=28.0, high=82.0, critical=100.0
-                ),
-                misc.AttributeDict(
-                    label="Core 4", current=30.0, high=82.0, critical=100.0
-                ),
-                misc.AttributeDict(
-                    label="Core 5", current=28.0, high=82.0, critical=100.0
-                ),
-            ],
-            "acpitz": [
-                misc.AttributeDict(label="", current=16.8, high=18.8, critical=18.8),
-                misc.AttributeDict(label="", current=27.8, high=119.0, critical=119.0),
-                misc.AttributeDict(label="", current=29.8, high=119.0, critical=119.0),
-            ],
-        }
-    }
-
-    with patch("i3pyblocks.blocks.ps.psutil", **mock_config):
+    with patch(**PSUTIL_MOCK_CONFIG) as mock_psutil:
+        mock_psutil.configure_mock(
+            **{
+                "sensors_temperatures.return_value": {
+                    "coretemp": [
+                        misc.AttributeDict(
+                            label="Package id 0",
+                            current=78.0,
+                            high=82.0,
+                            critical=100.0,
+                        ),
+                        misc.AttributeDict(
+                            label="Core 0", current=29.0, high=82.0, critical=100.0
+                        ),
+                        misc.AttributeDict(
+                            label="Core 1", current=28.0, high=82.0, critical=100.0
+                        ),
+                        misc.AttributeDict(
+                            label="Core 2", current=28.0, high=82.0, critical=100.0
+                        ),
+                        misc.AttributeDict(
+                            label="Core 3", current=28.0, high=82.0, critical=100.0
+                        ),
+                        misc.AttributeDict(
+                            label="Core 4", current=30.0, high=82.0, critical=100.0
+                        ),
+                        misc.AttributeDict(
+                            label="Core 5", current=28.0, high=82.0, critical=100.0
+                        ),
+                    ],
+                    "acpitz": [
+                        misc.AttributeDict(
+                            label="", current=16.8, high=18.8, critical=18.8
+                        ),
+                        misc.AttributeDict(
+                            label="", current=27.8, high=119.0, critical=119.0
+                        ),
+                        misc.AttributeDict(
+                            label="", current=29.8, high=119.0, critical=119.0
+                        ),
+                    ],
+                }
+            }
+        )
         instance_default = ps.SensorsTemperaturesBlock(
             format="{icon} {label} {current} {high} {critical}"
         )
@@ -264,17 +299,18 @@ async def test_sensors_temperature_block():
 
 @pytest.mark.asyncio
 async def test_virtual_memory_block():
-    mock_config = {
-        "virtual_memory.return_value": misc.AttributeDict(
-            total=16758484992,
-            available=13300297728,
-            percent=95.6,
-            used=2631917568,
-            free=10560126976,
+    with patch(**PSUTIL_MOCK_CONFIG) as mock_psutil:
+        mock_psutil.configure_mock(
+            **{
+                "virtual_memory.return_value": misc.AttributeDict(
+                    total=16758484992,
+                    available=13300297728,
+                    percent=95.6,
+                    used=2631917568,
+                    free=10560126976,
+                )
+            }
         )
-    }
-
-    with patch("i3pyblocks.blocks.ps.psutil", **mock_config):
         instance = ps.VirtualMemoryBlock(
             format="{icon} {total:.1f} {available:.1f} {used:.1f} {free:.1f} {percent}",
         )

--- a/tests/blocks/test_pulse.py
+++ b/tests/blocks/test_pulse.py
@@ -41,21 +41,25 @@ def mock_event(block_instance, facility):
 
 
 def test_pulse_audio_block():
-    mock_config = {
-        **DEFAULT_MOCK_CONFIG,
-        "Pulse.return_value.__enter__.return_value.sink_info.side_effect": [
-            SINK,
-            SINK,
-            SINK,
-            SINK_MUTE,
-        ],
-        "Pulse.return_value.__enter__.return_value.volume_get_all_chans.side_effect": [
-            0.0,
-            0.2,
-            0.8,
-        ],
-    }
-    with patch("i3pyblocks.blocks.pulse.pulsectl", **mock_config):
+    with patch(
+        "i3pyblocks.blocks.pulse.pulsectl", autospec=True, spec_set=True
+    ) as mock_pulse:
+        mock_pulse.configure_mock(
+            **{
+                **DEFAULT_MOCK_CONFIG,
+                "Pulse.return_value.__enter__.return_value.sink_info.side_effect": [
+                    SINK,
+                    SINK,
+                    SINK,
+                    SINK_MUTE,
+                ],
+                "Pulse.return_value.__enter__.return_value.volume_get_all_chans.side_effect": [
+                    0.0,
+                    0.2,
+                    0.8,
+                ],
+            }
+        )
         instance = pulse.PulseAudioBlock()
 
         # If volume is 0%, returns Colors.URGENT
@@ -86,23 +90,27 @@ def test_pulse_audio_block():
 
 @pytest.mark.asyncio
 async def test_pulse_audio_block_click_handler():
-    mock_config = {
-        **DEFAULT_MOCK_CONFIG,
-        "Pulse.return_value.__enter__.return_value.sink_info.side_effect": [
-            SINK,
-            SINK,
-            SINK,
-            SINK,
-            SINK,
-            SINK,
-            SINK,
-            SINK,
-            SINK_MUTE,
-        ],
-    }
     with patch(
-        "i3pyblocks.blocks.pulse.pulsectl", **mock_config
-    ) as mock_pulsectl, patch("i3pyblocks.blocks.pulse.subprocess") as mock_subprocess:
+        "i3pyblocks.blocks.pulse.pulsectl", autospec=True, spec_set=True
+    ) as mock_pulsectl, patch(
+        "i3pyblocks.blocks.pulse.subprocess", autospec=True, spec_set=True
+    ) as mock_subprocess:
+        mock_pulsectl.configure_mock(
+            **{
+                **DEFAULT_MOCK_CONFIG,
+                "Pulse.return_value.__enter__.return_value.sink_info.side_effect": [
+                    SINK,
+                    SINK,
+                    SINK,
+                    SINK,
+                    SINK,
+                    SINK,
+                    SINK,
+                    SINK,
+                    SINK_MUTE,
+                ],
+            }
+        )
         instance = pulse.PulseAudioBlock(
             command="command -c",
         )

--- a/tests/blocks/test_shell.py
+++ b/tests/blocks/test_shell.py
@@ -31,19 +31,22 @@ async def test_shell_block():
 
 @pytest.mark.asyncio
 async def test_shell_block_click_handler():
-    mock_config = {
-        "arun": CoroutineMock(),
-        "arun.return_value": (
-            misc.AttributeDict(
-                stdout="stdout\n",
-                stderr="stderr\n",
-                returncode=0,
-            )
-        ),
-        "PIPE": subprocess.PIPE,
-    }
-
-    with patch("i3pyblocks.blocks.shell.subprocess", **mock_config) as mock_subprocess:
+    with patch(
+        "i3pyblocks.blocks.shell.subprocess", autospec=True, spec_set=True
+    ) as mock_subprocess:
+        mock_subprocess.configure_mock(
+            **{
+                "arun": CoroutineMock(),
+                "arun.return_value": (
+                    misc.AttributeDict(
+                        stdout="stdout\n",
+                        stderr="stderr\n",
+                        returncode=0,
+                    )
+                ),
+                "PIPE": subprocess.PIPE,
+            }
+        )
         instance = shell.ShellBlock(
             command="exit 0",
             command_on_click={

--- a/tests/blocks/test_x11.py
+++ b/tests/blocks/test_x11.py
@@ -7,17 +7,24 @@ x11 = pytest.importorskip("i3pyblocks.blocks.x11")
 
 @pytest.mark.asyncio
 async def test_dpms_block():
-    mock_config = {
-        "Display.return_value.dpms_info.side_effect": [
-            # One for run() call, another one for click_handler()
-            misc.AttributeDict(state=1),
-            misc.AttributeDict(state=1),
-            # One for run() call, another one for click_handler()
-            misc.AttributeDict(state=0),
-            misc.AttributeDict(state=0),
-        ]
-    }
-    with patch("i3pyblocks.blocks.x11.Xdisplay", **mock_config) as mock_Xdisplay:
+    with patch(
+        # Display.dpms_info() is generated at runtime so can't autospec here
+        "i3pyblocks.blocks.x11.Xdisplay",
+        autospec=False,
+        spec_set=True,
+    ) as mock_Xdisplay:
+        mock_Xdisplay.configure_mock(
+            **{
+                "Display.return_value.dpms_info.side_effect": [
+                    # One for run() call, another one for click_handler()
+                    misc.AttributeDict(state=1),
+                    misc.AttributeDict(state=1),
+                    # One for run() call, another one for click_handler()
+                    misc.AttributeDict(state=0),
+                    misc.AttributeDict(state=0),
+                ]
+            }
+        )
         mock_Display = mock_Xdisplay.Display.return_value
 
         instance = x11.DPMSBlock()


### PR DESCRIPTION
Use `autospec=True` and `spec_set=True` when possible to make Mocks stricter.

This way, we at least ensure that the methods we're mocking actually exists and that we are calling them right (same number of parameters).