### PR TITLE
Open PR to bump-versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ name: Publish
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   deploy:
@@ -40,7 +40,7 @@ jobs:
         python setup.py sdist bdist_wheel
 
     - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@v1
       with:
         password: ${{ secrets.pypi_password }}
 
@@ -50,9 +50,13 @@ jobs:
         VERSION="${GITHUB_REF##*/}-dev"
         VERSION_FILE='i3pyblocks/__version__.py'
         echo "__version__ = \"${VERSION}\"" > "${VERSION_FILE}"
-        git config --global user.name 'Thiago Kenji Okada'
-        git config --global user.email 'thiagokokada@users.noreply.github.com'
-        git add "${VERSION_FILE}"
-        git commit -m "Bump version"
-        git push origin HEAD:master
       shell: bash
+
+    - name: Create PR to bump version
+      uses: peter-evans/create-pull-request@v3
+      with:
+        commit-message: Bump version
+        title: Bump version
+        body: Bump development version.
+        branch: bump-version
+        base: master


### PR DESCRIPTION
GitHub Actions bot can't commit directly to `master` branch since it will hit the branch protection rules of `master`. We can disable the rules to allow it to commit, but an alternative is to make the bot commit to a branch and open a PR that can be merged after review.

So do the later. This will make the process less automated, but at least it should work.