### PR TITLE
Improve NetworkSpeedBlock speed measurement

### DIFF
--- a/tests/blocks/test_ps.py
+++ b/tests/blocks/test_ps.py
@@ -131,7 +131,9 @@ async def test_network_speed_block_down():
 
 @pytest.mark.asyncio
 async def test_network_speed_block_up():
-    with patch(**PSUTIL_MOCK_CONFIG) as mock_psutil:
+    with patch(**PSUTIL_MOCK_CONFIG) as mock_psutil, patch(
+        "i3pyblocks.blocks.ps.time"
+    ) as mock_time:
         mock_psutil.configure_mock(
             **{
                 "net_if_stats.return_value": {
@@ -174,8 +176,10 @@ async def test_network_speed_block_up():
                 ],
             }
         )
+        mock_time.time.return_value = 3.328857660293579
         instance = ps.NetworkSpeedBlock(format_up="{interface} {upload} {download}")
 
+        mock_time.time.return_value = 6.328857660293579
         await instance.run()
 
         result = instance.result()


### PR DESCRIPTION
We used to depend on `i3pyblocks.blocks.base.PollingBlock.sleep`, but this is not necessary accurate. Instead let's calculate the actual time between the last call and the current call. This should make the measurement more accurate.