### PR TITLE
Disable screen saver in CaffeineBlock

### DIFF
--- a/example.py
+++ b/example.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import psutil
 
 from i3pyblocks import Runner, types, utils
-from i3pyblocks.blocks import (  # x11,
+from i3pyblocks.blocks import (  # shell,
     datetime,
     dbus,
     http,
@@ -15,7 +15,7 @@ from i3pyblocks.blocks import (  # x11,
     inotify,
     ps,
     pulse,
-    shell,
+    x11,
 )
 
 # Configure logging, so we can have debug information available in
@@ -119,23 +119,25 @@ async def main():
     # is shown
     # When `format_on` is being shown, clicking on it runs `command_off`,
     # while when `format_off` is being shown, clicking on it runs `command_on`
-    await runner.register_block(
-        shell.ToggleBlock(
-            command_state="xset q | grep -Fo 'DPMS is Enabled'",
-            command_on="xset s on +dpms",
-            command_off="xset s off -dpms",
-            format_on="  ",
-            format_off="  ",
-        )
-    )
-
-    # This is equivalent to the example above, but using pure Python
+    # We are using it below to simulate the popular Caffeine extension in
+    # Gnome and macOS
     # await runner.register_block(
-    #     x11.DPMSBlock(
-    #         format_on="  ",
-    #         format_off="  ",
+    #     shell.ToggleBlock(
+    #         command_state="xset q | grep -Fo 'DPMS is Enabled'",
+    #         command_on="xset s on +dpms",
+    #         command_off="xset s off -dpms",
+    #         format_on="  ",
+    #         format_off="  ",
     #     )
     # )
+
+    # This is equivalent to the example above, but using pure Python
+    await runner.register_block(
+        x11.CaffeineBlock(
+            format_on="  ",
+            format_off="  ",
+        )
+    )
 
     # KbddBlock uses D-Bus to get the keyboard layout information updates, so
     # it is very efficient (i.e.: there is no polling). But it needs `kbdd`

--- a/i3pyblocks/blocks/x11.py
+++ b/i3pyblocks/blocks/x11.py
@@ -1,7 +1,8 @@
 """Blocks related to X11, based on `python-xlib`_.
 
-Blocks dedicated to control some X11 features. For example, ``DPMSBlock``
-shows the state of DPMS and allow you to toggle DPMS between ON and OFF.
+Blocks dedicated to control some X11 features. For example, ``CaffeineBlock``
+shows the state of DPMS and screensaver and allow you to toggle DPMS between
+ON and OFF.
 
 Since query ``python-xlib`` calls are blocking, we execute than in a
 ThreadPoolExecutor to avoid locking up the i3pyblocks. Since most X11 calls
@@ -20,19 +21,17 @@ from Xlib.ext import dpms  # noqa: F401 (ensure that Xlib.ext.dpms is available)
 from i3pyblocks import blocks
 
 
-class DPMSBlock(blocks.PollingBlock):
+class CaffeineBlock(blocks.PollingBlock):
     r"""Block that controls of X11 DPMS and screensaver.
 
-    It shows the state of `DPMS`_ and also allow toggling it ON and OFF,
-    basically enabling or disabling display energy savings, and also enables
-    disables the screensaver.
+    When turned on, this blocks disables both `DPMS`_ and screensaver,
+    effectively, keeping your screen on. When it is turned off this block
+    re-enables both `DPMS`_ and screensaver. This is very similar to
+    `Caffeine`_ extension in Gnome, or `Amphetamine`_ on macOS.
 
-    This is very similar to `Caffeine`_ extension in Gnome, or `Amphetamine`_
-    on macOS.
+    :param format_on: format string to shown when DPMS and screensaver is off.
 
-    :param format_on: format string to shown when DPMS is on.
-
-    :param format_off: format string to shown when DPMS is off.
+    :param format_off: format string to shown when DPMS and screensaver is on.
 
     :param sleep: Sleep in seconds between each call to
         :meth:`~i3pyblocks.blocks.base.PollingBlock.run()`.
@@ -50,8 +49,8 @@ class DPMSBlock(blocks.PollingBlock):
 
     def __init__(
         self,
-        format_on: str = "DPMS ON",
-        format_off: str = "DPMS OFF",
+        format_on: str = "CAFFEINE ON",
+        format_off: str = "CAFFEINE OFF",
         sleep: int = 1,
         **kwargs,
     ) -> None:
@@ -99,4 +98,4 @@ class DPMSBlock(blocks.PollingBlock):
     async def run(self) -> None:
         state = await self.get_state()
 
-        self.update(self.format_on if state else self.format_off)
+        self.update(self.format_off if state else self.format_on)

--- a/tests/blocks/test_x11.py
+++ b/tests/blocks/test_x11.py
@@ -7,7 +7,7 @@ x11 = pytest.importorskip("i3pyblocks.blocks.x11")
 
 
 @pytest.mark.asyncio
-async def test_dpms_block():
+async def test_caffeine_block():
     with patch(
         # Display.dpms_info() is generated at runtime so can't autospec here
         "i3pyblocks.blocks.x11.display",
@@ -28,10 +28,10 @@ async def test_dpms_block():
         )
         mock_Display = mock_display.Display.return_value
 
-        instance = x11.DPMSBlock()
+        instance = x11.CaffeineBlock()
 
         await instance.run()
-        assert instance.result()["full_text"] == "DPMS ON"
+        assert instance.result()["full_text"] == "CAFFEINE OFF"
 
         await instance.click_handler()
         mock_Display.dpms_disable.assert_called_once()
@@ -45,7 +45,7 @@ async def test_dpms_block():
         mock_Display.reset_mock()
 
         await instance.run()
-        assert instance.result()["full_text"] == "DPMS OFF"
+        assert instance.result()["full_text"] == "CAFFEINE ON"
 
         await instance.click_handler()
         mock_Display.dpms_enable.assert_called_once()


### PR DESCRIPTION
Renamed `i3pyblocks.blocks.x11.DPMSBlock` to `i3pyblocks.blocks.x11.CaffeineBlock` since this is a better representation of the name.

This is a breaking change, but I think there isn't many people using this yet so better do it now than later.