### PR TITLE
Using PEP-517/PEP-518

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,11 +33,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel
+        pip install pep517
 
     - name: Build a binary wheel and a source tarball
       run: |
-        python setup.py sdist bdist_wheel
+        python -m pep517.build --source --binary --out-dir dist/
 
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import setuptools
 
 with open("i3pyblocks/__version__.py", "r") as f:
+    __version__ = None
     exec(f.read())
 
 with open("README.md", "r") as f:

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 import setuptools
 
-from i3pyblocks.__version__ import __version__
+with open("i3pyblocks/__version__.py", "r") as f:
+    exec(f.read())
 
-with open("README.md", "r") as fh:
-    long_description = fh.read()
+with open("README.md", "r") as f:
+    long_description = f.read()
 
 setuptools.setup(
     name="i3pyblocks",


### PR DESCRIPTION
This blog post was very informative: https://snarky.ca/what-the-heck-is-pyproject-toml/

This PR only adds `pyproject.toml` compatible with PEP-517/PEP-518 specification and make the necessary changes for it to work (since the builds are now done in isolation, it already found some issues in the current `setup.py` file). But it does not use `setup.cfg` in place of `setup.py` for two reasons:

- This needs a reasonable recently version of setuptools and not all distros have it yet
- There is still no support for editable installs except if I keep a `setup.py` file as a workaround

Also, use `pep517` to build wheels instead of `setuptools` and `wheels` combination, since now we declare our build tools in `pyproject.toml`.