### PR TITLE
Switch to python-build instead of pep517

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,11 +33,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pep517
+        pip install build
 
     - name: Build a binary wheel and a source tarball
       run: |
-        python -m pep517.build --source --binary --out-dir dist/ .
+        python -m build --wheel --sdist -o dist/ .
 
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@v1.4.1


### PR DESCRIPTION
`pep517.build` is going to be deprecated: https://github.com/pypa/pep517/pull/83

So let's use a tool that explicitly has an interface we can use to build.