### PR TITLE
Add PollingSyncBlock

### DIFF
--- a/docs/creating-a-new-block.rst
+++ b/docs/creating-a-new-block.rst
@@ -264,8 +264,9 @@ a similar way.
 When to use each base block?
 ----------------------------
 
-Generally using :class:`~i3pyblocks.blocks.base.PollingBlock` is the easiest
-way to start. However it is not necessary the most efficient way.
+Generally using either :class:`~i3pyblocks.blocks.base.PollingBlock` (for asyncio)
+or :class:`~i3pyblocks.blocks.base.PollingSyncBlock` (for non-asyncio) [2]_ is
+the easiest way to start. However it is not necessary the most efficient way.
 
 For example, volume is not something that is changed frequently. You may
 change the volume of your system once or twice until you find a confortable
@@ -296,7 +297,7 @@ for projects that integrates well with `asyncio`_. Just implement
 However, some projects doesn't integrate well with *asyncio* (i.e.: their
 methods are not *async*). Using them with :class:`~i3pyblocks.blocks.base.Block`
 would freeze i3pyblocks completely until some update on them happened.
-In those cases, you can use :class:`~i3pyblocks.blocks.base.ExecutorBlock`.
+In those cases, you can use :class:`~i3pyblocks.blocks.base.SyncBlock`.
 It runs the code inside an `Executor`_, that can be either a thread or a process,
 so the updates inside this block doesn't affect the rest of i3pyblocks. The
 usage ends up being very similar to before, just without *async/await* keywords:
@@ -308,6 +309,11 @@ usage ends up being very similar to before, just without *async/await* keywords:
             result = wait_for_event_loop()
             self.update(result)
 
+.. [2] :class:`~i3pyblocks.blocks.base.PollingBlock` should be your first choice
+   even for non-asyncio dependencies if the calls are cheap, since it is more
+   efficient. :class:`~i3pyblocks.blocks.base.PollingSyncBlock` is only recommended
+   if your calls are slow and synchronous (i.e.: they may need a network or `IPC`_
+   communication).
 .. _`event loop`:
      https://en.wikipedia.org/wiki/Event_loop
 .. _`PulseAudio`:
@@ -318,13 +324,15 @@ usage ends up being very similar to before, just without *async/await* keywords:
      https://docs.python.org/3/library/asyncio.html
 .. _`Executor`:
     https://docs.python.org/3/library/concurrent.futures.html
+.. _`IPC`:
+    https://en.wikipedia.org/wiki/Inter-process_communication
 
 .. seealso::
 
    There is multiple examples of each kind of base block usage in i3pyblocks
    already. For examples of :class:`~i3pyblocks.blocks.base.PollingBlock`
    check :mod:`i3pyblocks.blocks.ps` namespace, for examples of
-   :class:`~i3pyblocks.blocks.base.ExecutorBlock` check
+   :class:`~i3pyblocks.blocks.base.SyncBlock` check
    :class:`~i3pyblocks.blocks.pulse.PulseAudioBlock`, and for examples of
    event-based blocks using :class:`~i3pyblocks.blocks.base.Block` check
    :mod:`i3pyblocks.blocks.inotify` namespace.

--- a/i3pyblocks/_internal/misc.py
+++ b/i3pyblocks/_internal/misc.py
@@ -26,7 +26,7 @@ def non_nullable_dict(**kwargs) -> Dict:
 
 
 def run_async(fn: Callable, executor: Executor = None) -> Callable[..., Awaitable[Any]]:
-    r"""Calls an sync function async.
+    """Calls an sync function async.
 
     Based on here: https://dev.to/0xbf/turn-sync-function-to-async-python-tips-58nn.
 

--- a/i3pyblocks/blocks/pulse.py
+++ b/i3pyblocks/blocks/pulse.py
@@ -4,7 +4,7 @@ This module contains PulseAudioBlock, that uses ``pulsectl`` to show/adjust
 volume in systems that runs `PulseAudio`_.
 
 ``pulsectl`` uses its own event loop so this module is based on
-``ExecutorBlock`` running it in a separate thread, but this module should be
+``SyncBlock`` running it in a separate thread, but this module should be
 pretty efficient since it react to events from PulseAudio itself.
 
 Needs PulseAudio installed in your computer, or you will receive the following
@@ -63,7 +63,7 @@ class PulseAudioBlock(blocks.SyncBlock):
     :param command: Program to run when this block is right clicked.
 
     :param \*\*kwargs: Extra arguments to be passed to
-        :class:`~i3pyblocks.blocks.base.ExecutorBlock` class.
+        :class:`~i3pyblocks.blocks.base.SyncBlock` class.
 
     .. _pavucontrol:
       https://freedesktop.org/software/pulseaudio/pavucontrol/

--- a/i3pyblocks/blocks/pulse.py
+++ b/i3pyblocks/blocks/pulse.py
@@ -27,7 +27,7 @@ from i3pyblocks._internal import misc, models, subprocess
 
 
 # Based on: https://git.io/fjbHp
-class PulseAudioBlock(blocks.ExecutorBlock):
+class PulseAudioBlock(blocks.SyncBlock):
     r"""Block that shows volume and other info from default PulseAudio sink.
 
     This Block shows the volume of the current default PulseAudio sink, and
@@ -163,7 +163,7 @@ class PulseAudioBlock(blocks.ExecutorBlock):
             sink = pulse.sink_info(self.sink_index)
             pulse.volume_change_all_chans(sink, volume)
 
-    async def click_handler(self, button: int, **_kwargs) -> None:
+    def click_handler_sync(self, button: int, **_kwargs) -> None:
         """PulseAudioBlock click handlers
 
         On left click it opens the command specified in ``command`` attribute.
@@ -182,7 +182,7 @@ class PulseAudioBlock(blocks.ExecutorBlock):
 
         self.update_status()
 
-    def run(self) -> None:
+    def run_sync(self) -> None:
         self.find_sink_index()
         self.update_status()
 

--- a/i3pyblocks/blocks/x11.py
+++ b/i3pyblocks/blocks/x11.py
@@ -16,10 +16,9 @@ from Xlib import X, display
 from Xlib.ext import dpms  # noqa: F401 (ensure that Xlib.ext.dpms is available)
 
 from i3pyblocks import blocks
-from i3pyblocks._internal import misc
 
 
-class CaffeineBlock(blocks.PollingBlock):
+class CaffeineBlock(blocks.PollingSyncBlock):
     r"""Block that controls of X11 DPMS and screensaver.
 
     When turned on, this blocks disables both `DPMS`_ and screensaver,
@@ -57,12 +56,12 @@ class CaffeineBlock(blocks.PollingBlock):
         self.format_off = format_off
         self.display = display.Display()
 
-    async def get_state(self) -> bool:
-        info = await misc.run_async(self.display.dpms_info)()
+    def get_state(self) -> bool:
+        info = self.display.dpms_info()
         return bool(int(info.state))
 
-    async def click_handler(self, **_kwargs) -> None:
-        state = await self.get_state()
+    def click_handler_sync(self, **_kwargs) -> None:
+        state = self.get_state()
 
         if state:
             self.display.dpms_disable()
@@ -81,10 +80,9 @@ class CaffeineBlock(blocks.PollingBlock):
                 timeout=-1,
             )
 
-        await misc.run_async(self.display.sync)()
-        await self.run()
+        self.display.sync()
+        self.run_sync()
 
-    async def run(self) -> None:
-        state = await self.get_state()
-
+    def run_sync(self) -> None:
+        state = self.get_state()
         self.update(self.format_off if state else self.format_on)

--- a/tests/blocks/test_pulse.py
+++ b/tests/blocks/test_pulse.py
@@ -63,13 +63,13 @@ def test_pulse_audio_block():
         instance = pulse.PulseAudioBlock()
 
         # If volume is 0%, returns Colors.URGENT
-        mock_event(instance, facility="server")
+        instance.run_sync()
         result = instance.result()
         assert result.get("full_text") == "V: 0%"
         assert result.get("color") == types.Color.URGENT
 
         # If volume is 20%, returns Colors.WARN
-        mock_event(instance, facility="sink")
+        mock_event(instance, facility="server")
         result = instance.result()
         assert result.get("full_text") == "V: 20%"
         assert result.get("color") == types.Color.WARN
@@ -88,8 +88,7 @@ def test_pulse_audio_block():
         assert result.get("color") == types.Color.URGENT
 
 
-@pytest.mark.asyncio
-async def test_pulse_audio_block_click_handler():
+def test_pulse_audio_block_click_handler_sync():
     with patch(
         "i3pyblocks.blocks.pulse.pulsectl", autospec=True, spec_set=True
     ) as mock_pulsectl, patch(
@@ -119,7 +118,7 @@ async def test_pulse_audio_block_click_handler():
         mock_pulse = mock_pulsectl.Pulse.return_value
 
         # LEFT_BUTTON should run command
-        await instance.click_handler(types.MouseButton.LEFT_BUTTON)
+        instance.click_handler_sync(types.MouseButton.LEFT_BUTTON)
         mock_subprocess.popener.assert_called_once_with(("command", "-c"))
 
         context_manager_mock = mock_pulse.__enter__
@@ -129,19 +128,19 @@ async def test_pulse_audio_block_click_handler():
         volume_change_all_chans_mock = (
             context_manager_mock.return_value.volume_change_all_chans
         )
-        await instance.click_handler(types.MouseButton.SCROLL_UP)
+        instance.click_handler_sync(types.MouseButton.SCROLL_UP)
         volume_change_all_chans_mock.assert_called_once_with(SINK, 0.05)
 
         volume_change_all_chans_mock.reset_mock()
 
-        await instance.click_handler(types.MouseButton.SCROLL_DOWN)
+        instance.click_handler_sync(types.MouseButton.SCROLL_DOWN)
         volume_change_all_chans_mock.assert_called_once_with(SINK, -0.05)
 
         # When not mute, pressing RIGHT_BUTTON will mute it
-        await instance.click_handler(types.MouseButton.RIGHT_BUTTON)
+        instance.click_handler_sync(types.MouseButton.RIGHT_BUTTON)
         mute_mock.assert_called_once_with(SINK, mute=True)
 
         mute_mock.reset_mock()
 
-        await instance.click_handler(types.MouseButton.RIGHT_BUTTON)
+        instance.click_handler_sync(types.MouseButton.RIGHT_BUTTON)
         mute_mock.assert_called_once_with(SINK_MUTE, mute=False)

--- a/tests/blocks/test_x11.py
+++ b/tests/blocks/test_x11.py
@@ -6,8 +6,7 @@ X = pytest.importorskip("Xlib.X")
 x11 = pytest.importorskip("i3pyblocks.blocks.x11")
 
 
-@pytest.mark.asyncio
-async def test_caffeine_block():
+def test_caffeine_block():
     with patch(
         # Display.dpms_info() is generated at runtime so can't autospec here
         "i3pyblocks.blocks.x11.display",
@@ -19,10 +18,10 @@ async def test_caffeine_block():
 
         instance = x11.CaffeineBlock()
 
-        await instance.run()
+        instance.run_sync()
         assert instance.result()["full_text"] == "CAFFEINE OFF"
 
-        await instance.click_handler()
+        instance.click_handler_sync()
         mock_Display.dpms_disable.assert_called_once()
         mock_Display.set_screen_saver.assert_called_once_with(
             allow_exposures=X.DefaultExposures,
@@ -34,10 +33,10 @@ async def test_caffeine_block():
         mock_Display.reset_mock()
         mock_Display.dpms_info.return_value = misc.AttributeDict(state=0)
 
-        await instance.run()
+        instance.run_sync()
         assert instance.result()["full_text"] == "CAFFEINE ON"
 
-        await instance.click_handler()
+        instance.click_handler_sync()
         mock_Display.dpms_enable.assert_called_once()
         mock_Display.set_screen_saver.assert_called_once_with(
             allow_exposures=X.DefaultExposures,


### PR DESCRIPTION
**Breaking change**

This is the equivalent of `PollingBlock`, but made for cases when asyncio is not supported by the block and the calls for the functions maybe slow. The case used as an example here is `i3pyblocks.blocks.x11.CaffeineBlock`, since each call of X11 can block for an unspecified amount of time.

Also rename `ExecutorBlock` to `SyncBlock.` This new name is a much better description of what this block does. It also introduces `click_handler_sync()` and `signal_handler_sync()`, and renames the main method from `run()` to `run_sync()`. With this, it is much easier to create a correct block using a fully synchronous dependency.

Closes issue #118.