### PR TITLE
Rename i3pyblocks.blocks.base.SyncBlock.run_sync to start_sync

### DIFF
--- a/docs/creating-a-new-block.rst
+++ b/docs/creating-a-new-block.rst
@@ -291,7 +291,7 @@ for projects that integrates well with `asyncio`_. Just implement
 
     async def start(self):
         while True:
-            result = await wait_for_event_loop()
+            result = await wait_for_async_event()
             self.update(result)
 
 However, some projects doesn't integrate well with *asyncio* (i.e.: their
@@ -300,20 +300,21 @@ would freeze i3pyblocks completely until some update on them happened.
 In those cases, you can use :class:`~i3pyblocks.blocks.base.SyncBlock`.
 It runs the code inside an `Executor`_, that can be either a thread or a process,
 so the updates inside this block doesn't affect the rest of i3pyblocks. The
-usage ends up being very similar to before, just without *async/await* keywords:
+usage ends up being very similar to before, just without *async/await* keywords
+and using :meth:`~i3pyblocks.blocks.base.SyncBlock.start_sync` instead:
 
 .. code-block:: python
 
-    def start(self):
+    def start_sync(self):
         while True:
-            result = wait_for_event_loop()
+            result = wait_for_sync_event()
             self.update(result)
 
 .. [2] :class:`~i3pyblocks.blocks.base.PollingBlock` should be your first choice
    even for non-asyncio dependencies if the calls are cheap, since it is more
    efficient. :class:`~i3pyblocks.blocks.base.PollingSyncBlock` is only recommended
-   if your calls are slow and synchronous (i.e.: they may need a network or `IPC`_
-   communication).
+   if your calls are **slow** and **synchronous** (i.e.: they need a network or
+   `IPC`_ communication).
 .. _`event loop`:
      https://en.wikipedia.org/wiki/Event_loop
 .. _`PulseAudio`:
@@ -331,9 +332,11 @@ usage ends up being very similar to before, just without *async/await* keywords:
 
    There is multiple examples of each kind of base block usage in i3pyblocks
    already. For examples of :class:`~i3pyblocks.blocks.base.PollingBlock`
-   check :mod:`i3pyblocks.blocks.ps` namespace, for examples of
+   check :mod:`i3pyblocks.blocks.ps` namespace, for example of a
    :class:`~i3pyblocks.blocks.base.SyncBlock` check
-   :class:`~i3pyblocks.blocks.pulse.PulseAudioBlock`, and for examples of
+   :class:`~i3pyblocks.blocks.pulse.PulseAudioBlock`, for example of a
+   :class:`~i3pyblocks.blocks.base.PollingSyncBlock` check
+   :class:`~i3pyblocks.blocks.x11.CaffeineBlock` and for examples of
    event-based blocks using :class:`~i3pyblocks.blocks.base.Block` check
    :mod:`i3pyblocks.blocks.inotify` namespace.
 

--- a/i3pyblocks/blocks/pulse.py
+++ b/i3pyblocks/blocks/pulse.py
@@ -163,6 +163,9 @@ class PulseAudioBlock(blocks.SyncBlock):
             sink = pulse.sink_info(self.sink_index)
             pulse.volume_change_all_chans(sink, volume)
 
+    def signal_handler_sync(self, **_kwargs):
+        self.update_status()
+
     def click_handler_sync(self, button: int, **_kwargs) -> None:
         """PulseAudioBlock click handlers
 
@@ -182,7 +185,7 @@ class PulseAudioBlock(blocks.SyncBlock):
 
         self.update_status()
 
-    def run_sync(self) -> None:
+    def start_sync(self) -> None:
         self.find_sink_index()
         self.update_status()
 

--- a/tests/blocks/test_base.py
+++ b/tests/blocks/test_base.py
@@ -245,7 +245,7 @@ async def test_valid_sync_block():
             self.count = 0
             super().__init__(default_state=DEFAULT_STATE)
 
-        def run_sync(self):
+        def start_sync(self):
             self.count += 1
             self.update(str(self.count))
 
@@ -259,31 +259,6 @@ async def test_valid_sync_block():
         "name": "ValidSyncBlock",
     }
 
-    block.click_handler_sync(
-        x=1,
-        y=1,
-        button=types.MouseButton.LEFT_BUTTON,
-        relative_x=1,
-        relative_y=1,
-        width=1,
-        height=1,
-        modifiers=[],
-    )
-
-    assert block.result() == {
-        "full_text": "2",
-        "instance": str(block.id),
-        "name": "ValidSyncBlock",
-    }
-
-    block.signal_handler_sync(sig=signal.SIGHUP)
-
-    assert block.result() == {
-        "full_text": "3",
-        "instance": str(block.id),
-        "name": "ValidSyncBlock",
-    }
-
 
 @pytest.mark.asyncio
 async def test_sync_block_with_error():
@@ -292,7 +267,7 @@ async def test_sync_block_with_error():
             self.count = 0
             super().__init__(default_state=DEFAULT_STATE)
 
-        def run_sync(self):
+        def start_sync(self):
             raise Exception("Boom!")
 
     block = SyncBlockWithError()
@@ -333,6 +308,31 @@ async def test_valid_polling_sync_block():
 
     assert block.result() == {
         "full_text": "5",
+        "instance": str(block.id),
+        "name": "ValidPollingSyncBlock",
+    }
+
+    block.click_handler_sync(
+        x=1,
+        y=1,
+        button=types.MouseButton.LEFT_BUTTON,
+        relative_x=1,
+        relative_y=1,
+        width=1,
+        height=1,
+        modifiers=[],
+    )
+
+    assert block.result() == {
+        "full_text": "6",
+        "instance": str(block.id),
+        "name": "ValidPollingSyncBlock",
+    }
+
+    block.signal_handler_sync(sig=signal.SIGHUP)
+
+    assert block.result() == {
+        "full_text": "7",
         "instance": str(block.id),
         "name": "ValidPollingSyncBlock",
     }

--- a/tests/blocks/test_pulse.py
+++ b/tests/blocks/test_pulse.py
@@ -63,7 +63,7 @@ def test_pulse_audio_block():
         instance = pulse.PulseAudioBlock()
 
         # If volume is 0%, returns Colors.URGENT
-        instance.run_sync()
+        instance.start_sync()
         result = instance.result()
         assert result.get("full_text") == "V: 0%"
         assert result.get("color") == types.Color.URGENT


### PR DESCRIPTION
This will make the API more consistent, making `SyncBlock` pratically the same API as `Block`.