### PR TITLE
Refactor tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ alabaster==0.7.12         # via sphinx
 appdirs==1.4.4            # via black
 astroid==2.4.2            # via sphinx-autoapi
 async-timeout==3.0.1      # via aiohttp
-asynctest==0.13.0         # via i3pyblocks
 attrs==20.2.0             # via aiohttp, flake8-bugbear, pytest
 babel==2.8.0              # via sphinx
 black==20.8b1             # via i3pyblocks
@@ -32,6 +31,7 @@ jinja2==2.11.2            # via sphinx, sphinx-autoapi
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
+mock==4.0.2               # via i3pyblocks
 more-itertools==8.5.0     # via pytest
 multidict==4.7.6          # via aiohttp, yarl
 mypy-extensions==0.4.3    # via black, mypy

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setuptools.setup(
             "sphinx-rtd-theme",
         ],
         "test": [
-            "asynctest",
+            "mock>=4.0",
             "pytest",
             "pytest-aiohttp",
             "pytest-asyncio",

--- a/tests/_internal/test_misc.py
+++ b/tests/_internal/test_misc.py
@@ -1,8 +1,8 @@
 import asyncio
 from inspect import Parameter, Signature, signature
-from unittest.mock import patch
 
 import pytest
+from mock import patch
 
 from i3pyblocks._internal import misc
 

--- a/tests/blocks/test_datetime.py
+++ b/tests/blocks/test_datetime.py
@@ -1,7 +1,7 @@
 from datetime import datetime
-from unittest.mock import patch
 
 import pytest
+from mock import patch
 
 from i3pyblocks.blocks import datetime as m_datetime
 

--- a/tests/blocks/test_i3ipc.py
+++ b/tests/blocks/test_i3ipc.py
@@ -1,6 +1,6 @@
 import pytest
-from asynctest import CoroutineMock, patch
 from helpers import misc, task
+from mock import Mock, patch
 
 i3ipc = pytest.importorskip("i3pyblocks.blocks.i3ipc")
 
@@ -10,17 +10,11 @@ async def test_window_title_block():
     with patch(
         "i3pyblocks.blocks.i3ipc.i3ipc_aio", autospec=True, spec_set=True
     ) as mock_i3ipc_aio:
-        mock_i3ipc_aio.configure_mock(
-            **{
-                "Connection.return_value.connect": CoroutineMock(),
-                "Connection.return_value.main": CoroutineMock(),
-                "Connection.return_value.get_tree": CoroutineMock(),
-            }
-        )
         mock_connection = mock_i3ipc_aio.Connection.return_value
 
         tree_mock = mock_connection.get_tree.return_value
-        window_mock = tree_mock.find_focused
+        # For some reason this was mocked as a AsyncMock
+        window_mock = tree_mock.find_focused = Mock()
         window_mock.return_value = misc.AttributeDict(name="Hello")
 
         instance = i3ipc.WindowTitleBlock()

--- a/tests/blocks/test_inotify.py
+++ b/tests/blocks/test_inotify.py
@@ -2,8 +2,8 @@ import asyncio
 import signal
 
 import pytest
-from asynctest import CoroutineMock, patch
 from helpers import misc, task
+from mock import patch
 
 from i3pyblocks import types
 
@@ -164,7 +164,6 @@ async def test_backlight_block_click_handler(tmpdir):
     ) as mock_subprocess:
         mock_subprocess.configure_mock(
             **{
-                "arun": CoroutineMock(),
                 "arun.return_value": (misc.AttributeDict(returncode=0)),
             }
         )

--- a/tests/blocks/test_ps.py
+++ b/tests/blocks/test_ps.py
@@ -1,8 +1,8 @@
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 from helpers import misc
+from mock import patch
 
 from i3pyblocks import types
 

--- a/tests/blocks/test_pulse.py
+++ b/tests/blocks/test_pulse.py
@@ -1,7 +1,6 @@
-from unittest.mock import Mock, patch
-
 import pytest
 from helpers import misc
+from mock import Mock, patch
 
 from i3pyblocks import types
 

--- a/tests/blocks/test_shell.py
+++ b/tests/blocks/test_shell.py
@@ -1,8 +1,8 @@
 from asyncio import subprocess
 
 import pytest
-from asynctest import CoroutineMock, call, patch
 from helpers import misc
+from mock import call, patch
 
 from i3pyblocks import types
 from i3pyblocks.blocks import shell
@@ -36,7 +36,6 @@ async def test_shell_block_click_handler():
     ) as mock_subprocess:
         mock_subprocess.configure_mock(
             **{
-                "arun": CoroutineMock(),
                 "arun.return_value": (
                     misc.AttributeDict(
                         stdout="stdout\n",

--- a/tests/blocks/test_x11.py
+++ b/tests/blocks/test_x11.py
@@ -1,6 +1,6 @@
 import pytest
-from asynctest import patch
 from helpers import misc
+from mock import patch
 
 X = pytest.importorskip("Xlib.X")
 x11 = pytest.importorskip("i3pyblocks.blocks.x11")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,10 +2,9 @@ import asyncio
 import json
 import os
 import signal
-from unittest.mock import patch
 
 import pytest
-from asynctest import CoroutineMock
+from mock import patch
 
 from i3pyblocks import blocks, core, types
 from i3pyblocks.blocks import basic
@@ -331,13 +330,9 @@ async def test_runner_with_click_events(capsys):
 
     mock_input = [b"[\n", click_event, b","]
 
-    with patch(
-        "i3pyblocks._internal.misc.get_aio_reader", new=CoroutineMock()
-    ) as get_aio_reader_mock:
+    with patch("i3pyblocks._internal.misc.get_aio_reader") as get_aio_reader_mock:
         reader_mock = get_aio_reader_mock.return_value
-        reader_mock.readline = CoroutineMock()
         reader_mock.readline.return_value = mock_input[0]
-        reader_mock.readuntil = CoroutineMock()
         reader_mock.readuntil.side_effect = mock_input[1:]
 
         await runner.start(timeout=0.5)


### PR DESCRIPTION
Use a backport of `match` from Python >3.8, that includes `AsyncMock` instead of using `asynctest`. This simplified a lot of tests, but unfortunately also broke `i3pyblocks.blocks.dbus` tests. But since this namespace is already a mess, don't bother fixing it.