### PR TITLE
Fixing the MediaPlayerBlock relying on metadata always being present

### DIFF
--- a/i3pyblocks/blocks/dbus.py
+++ b/i3pyblocks/blocks/dbus.py
@@ -247,7 +247,7 @@ class MediaPlayerBlock(DbusBlock):
             **kwargs,
         )
         self.format = format
-        self.metadata: Dict[str, str] = {
+        self.metadata = {
             "artist": "",
             "title": "",
             "track_number": "",


### PR DESCRIPTION
Currently the `MediaPlayerBlock` is relying on getting all the required metadata every time there is an update. This works for *spotify*, but not for every player. For example *firefox* will only update the properties that did really change, breaking the block with a `KeyError`.

My patch saves the metadata inside the class and then on each update changes just the fields that were updated.